### PR TITLE
'extend type' schema support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -188,6 +188,15 @@ yargs
       if (schemaPaths.length === 1 && glob.hasMagic(schemaPaths[0])) {
         schemaPaths = glob.sync(schemaPaths[0]);
       }
+      
+      schemaPaths = schemaPaths
+        .map(schemaPath => path.resolve(schemaPath))
+        // Sort to normalize different glob expansions between different terminals.
+        .sort();
+
+      if (schemaPaths.length == 0) {
+        throw new ToolError( "Verify --schema argument. Unable to locate valid path.")
+      }
 
       const options = {
         passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] !== '',

--- a/src/introspectSchema.js
+++ b/src/introspectSchema.js
@@ -7,10 +7,7 @@ import { introspectionQuery } from 'graphql/utilities';
 
 import { ToolError } from './errors'
 
-export async function introspect(schemaContents, parsed=false) {
-  if( !parsed ) {
-    schemaContents = parse(schemaContents);
-  }
+export async function introspect(schemaContents) {
   let schema = buildASTSchema(schemaContents);
   const extensionDefs = schemaContents.definitions.filter((def) => def.kind === Kind.TYPE_EXTENSION_DEFINITION);
   if( extensionDefs.length > 0 )
@@ -25,13 +22,13 @@ export default async function introspectSchema(schemaPaths, outputPath) {
     if (!fs.existsSync(schemaPaths[0])) {
       throw new ToolError(`Cannot find GraphQL schema file: ${schemaPaths[0]}`);
     }
-    schemaContents = fs.readFileSync(schemaPaths[0]).toString();
+    schemaContents = parse(fs.readFileSync(schemaPaths[0]).toString());
   }
   else {
     schemaContents = loadAndMergeQueryDocuments(schemaPaths, 'gql');
   }
 
-  const result = await introspect(schemaContents, true);
+  const result = await introspect(schemaContents);
 
   if (result.errors) {
     throw new ToolError(`Errors in introspection query result: ${result.errors}`);

--- a/src/introspectSchema.js
+++ b/src/introspectSchema.js
@@ -1,22 +1,37 @@
 import * as fs from 'fs';
+import { loadSchema, loadAndMergeQueryDocuments } from './loading'
 
-import { buildASTSchema, graphql, parse } from 'graphql';
+import { buildASTSchema, extendSchema, graphql, parse } from 'graphql';
+import { Kind } from 'graphql/language';
 import { introspectionQuery } from 'graphql/utilities';
 
 import { ToolError } from './errors'
 
-export async function introspect(schemaContents) {
-  const schema = buildASTSchema(parse(schemaContents));
+export async function introspect(schemaContents, parsed=false) {
+  if( !parsed ) {
+    schemaContents = parse(schemaContents);
+  }
+  let schema = buildASTSchema(schemaContents);
+  const extensionDefs = schemaContents.definitions.filter((def) => def.kind === Kind.TYPE_EXTENSION_DEFINITION);
+  if( extensionDefs.length > 0 )
+    schema = extendSchema(schema, {...schemaContents, definitions:extensionDefs});
+
   return await graphql(schema, introspectionQuery);
 }
 
-export default async function introspectSchema(schemaPath, outputPath) {
-  if (!fs.existsSync(schemaPath)) {
-    throw new ToolError(`Cannot find GraphQL schema file: ${schemaPath}`);
+export default async function introspectSchema(schemaPaths, outputPath) {
+  let schemaContents;
+  if( schemaPaths.length === 1 ) {
+    if (!fs.existsSync(schemaPaths[0])) {
+      throw new ToolError(`Cannot find GraphQL schema file: ${schemaPaths[0]}`);
+    }
+    schemaContents = fs.readFileSync(schemaPaths[0]).toString();
+  }
+  else {
+    schemaContents = loadAndMergeQueryDocuments(schemaPaths, 'gql');
   }
 
-  const schemaContents = fs.readFileSync(schemaPath).toString();
-  const result = await introspect(schemaContents);
+  const result = await introspect(schemaContents, true);
 
   if (result.errors) {
     throw new ToolError(`Errors in introspection query result: ${result.errors}`);

--- a/test/introspectSchema.js
+++ b/test/introspectSchema.js
@@ -2,13 +2,14 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 
 import { introspect } from '../src/introspectSchema';
+import {parse} from "graphql";
 
 describe('Introspecting GraphQL schema documents', () => {
   test(`should generate valid introspection JSON file`, async () => {
     const schemaContents = readFileSync(join(__dirname, './starwars/schema.graphql')).toString();
     const expected = readFileSync(join(__dirname, './starwars/schema.json')).toString();
 
-    const schema = await introspect(schemaContents);
+    const schema = await introspect(parse(schemaContents));
 
     expect(JSON.stringify(schema, null, 2)).toEqual(expected);
   });

--- a/test/starwars/schema.graphql
+++ b/test/starwars/schema.graphql
@@ -134,6 +134,9 @@ type Starship {
   name: String!
   # Length of the starship, along the longest axis
   length(unit: LengthUnit = METER): Float
+}
+#validate "extend type" works
+extend type Starship {
   coordinates: [[Float!]!]
 }
 union SearchResult = Human | Droid | Starship


### PR DESCRIPTION
Added 'glob' for the schema argument (defaults to non-glob behavior).
Added extendSchema( ) calls for unified handling of the server-schema AST for both introspect/generate.
Modified star wars test script to include "extend type" in the graphqls test file.
