### PR TITLE
Change generated flow files extension to .js instead of .ts

### DIFF
--- a/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -89,7 +89,7 @@ export type HeroNameVariables = {|
   +episode?: ?Episode
 |};",
       },
-      "fileName": "HeroName.ts",
+      "fileName": "HeroName.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -130,7 +130,7 @@ export type humanFragment = {|
   +friends: ?$ReadOnlyArray<?humanFragment_friends>,
 |};",
       },
-      "fileName": "humanFragment.ts",
+      "fileName": "humanFragment.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -153,7 +153,7 @@ export type droidFragment = {|
   +appearsIn: $ReadOnlyArray<?Episode>,
 |};",
       },
-      "fileName": "droidFragment.ts",
+      "fileName": "droidFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -249,7 +249,7 @@ export type HeroNameVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroName.ts",
+      "fileName": "HeroName.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -290,7 +290,7 @@ export type humanFragment = {
   friends: ?Array<?humanFragment_friends>,
 };",
       },
-      "fileName": "humanFragment.ts",
+      "fileName": "humanFragment.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -313,7 +313,7 @@ export type droidFragment = {
   appearsIn: Array<?Episode>,
 };",
       },
-      "fileName": "droidFragment.ts",
+      "fileName": "droidFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -356,7 +356,7 @@ export type simpleFragment = {
   name: string,
 };",
       },
-      "fileName": "simpleFragment.ts",
+      "fileName": "simpleFragment.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -383,7 +383,7 @@ export type anotherFragment = {
   name: string,
 };",
       },
-      "fileName": "anotherFragment.ts",
+      "fileName": "anotherFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -431,7 +431,7 @@ export type simpleFragment = {
   name: string,
 };",
       },
-      "fileName": "simpleFragment.ts",
+      "fileName": "simpleFragment.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -476,7 +476,7 @@ export type anotherFragment_Human = {
 
 export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;",
       },
-      "fileName": "anotherFragment.ts",
+      "fileName": "anotherFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -525,7 +525,7 @@ export type CustomScalar = {
   commentTest: ?CustomScalar_commentTest
 };",
       },
-      "fileName": "CustomScalar.ts",
+      "fileName": "CustomScalar.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -585,7 +585,7 @@ export type HeroInlineFragmentVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroInlineFragment.ts",
+      "fileName": "HeroInlineFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -675,7 +675,7 @@ export type HeroNameVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroName.ts",
+      "fileName": "HeroName.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -777,7 +777,7 @@ export type HeroNameVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroName.ts",
+      "fileName": "HeroName.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -820,7 +820,7 @@ export type HeroNameVariables = {
   episode?: ?Episode
 };",
     },
-    "fileName": "HeroName.ts",
+    "fileName": "HeroName.js",
     "sourcePath": "/some/file/ComponentA.js",
   },
   Object {
@@ -855,7 +855,7 @@ export type SomeOtherVariables = {
   episode?: ?Episode
 };",
     },
-    "fileName": "SomeOther.ts",
+    "fileName": "SomeOther.js",
     "sourcePath": "/some/file/ComponentB.js",
   },
   Object {
@@ -891,7 +891,7 @@ export type ReviewMovieVariables = {
   review?: ?ReviewInput,
 };",
     },
-    "fileName": "ReviewMovie.ts",
+    "fileName": "ReviewMovie.js",
     "sourcePath": "GraphQL request",
   },
   Object {
@@ -914,7 +914,7 @@ export type someFragment = {
   appearsIn: Array<?Episode>,
 };",
     },
-    "fileName": "someFragment.ts",
+    "fileName": "someFragment.js",
     "sourcePath": "/some/file/ComponentB.js",
   },
 ]
@@ -1014,7 +1014,7 @@ export type HeroFragmentVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroFragment.ts",
+      "fileName": "HeroFragment.js",
       "sourcePath": "GraphQL request",
     },
     Object {
@@ -1037,7 +1037,7 @@ export type simpleFragment = {
   name: string,
 };",
       },
-      "fileName": "simpleFragment.ts",
+      "fileName": "simpleFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -1080,7 +1080,7 @@ export type SimpleFragment = {
   name: string,
 };",
       },
-      "fileName": "SimpleFragment.ts",
+      "fileName": "SimpleFragment.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -1140,7 +1140,7 @@ export type HeroNameVariables = {
   episode?: ?Episode
 };",
       },
-      "fileName": "HeroName.ts",
+      "fileName": "HeroName.js",
       "sourcePath": "GraphQL request",
     },
   ],
@@ -1219,7 +1219,7 @@ export type ReviewMovieVariables = {
   review?: ?ReviewInput,
 };",
       },
-      "fileName": "ReviewMovie.ts",
+      "fileName": "ReviewMovie.js",
       "sourcePath": "GraphQL request",
     },
   ],

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -78,7 +78,7 @@ export function generateSource(
 
       generatedFiles.push({
         sourcePath: operation.filePath,
-        fileName: `${operation.operationName}.ts`,
+        fileName: `${operation.operationName}.js`,
         content: new FlowGeneratedFile(output)
       });
     });
@@ -92,7 +92,7 @@ export function generateSource(
 
       generatedFiles.push({
         sourcePath: fragment.filePath,
-        fileName: `${fragment.fragmentName}.ts`,
+        fileName: `${fragment.fragmentName}.js`,
         content: new FlowGeneratedFile(output)
       });
     });


### PR DESCRIPTION
Currently when the output to `apollo codegen:generate` is not specified and the target is flow, all of the generated files have a .ts extension, but it should be .js.