### PR TITLE
Restore ability to put generated files in a directory relative to source

### DIFF
--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -55,7 +55,7 @@ ARGUMENTS
       Directory to which generated files will be written.
       - For TypeScript/Flow generators, this specifies a directory relative
       to each source file by default.
-      - For TypeScript/Flow generators with the "outputRelativeToCWD" flag
+      - For TypeScript/Flow generators with the "outputFlat" flag
       is set, and for the Swift generator, this specifies a file or
       directory (absolute or relative to the current working directory) to
       which:
@@ -94,10 +94,10 @@ OPTIONS
       operation ids (hashes) as properties on operation types [currently
       Swift-only]
 
-  --outputRelativeToCWD
+  --outputFlat
       By default, TypeScript/Flow will put each generated file in a
       directory next to its source file using the value of the "output" as
-      the directory name. Set "outputRelativeToCWD" to put all generated
+      the directory name. Set "outputFlat" to put all generated
       files in the directory relative to the current working directory
       defined by "output".
 

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -5,15 +5,18 @@
 Apollo CLI brings together your GraphQL clients and servers with tools for validating your schema, linting your operations for compatibility with your server, and generating static types for improved client-side type safety.
 
 <!-- toc -->
-* [Apollo CLI](#apollo-cli)
-* [Usage](#usage)
-* [Commands](#commands)
-* [Code Generation](#code-generation)
-* [Contributing](#contributing)
-<!-- tocstop -->
+
+- [Apollo CLI](#apollo-cli)
+- [Usage](#usage)
+- [Commands](#commands)
+- [Code Generation](#code-generation)
+- [Contributing](#contributing)
+  <!-- tocstop -->
 
 # Usage
+
 <!-- usage -->
+
 ```sh-session
 $ npm install -g apollo
 $ apollo COMMAND
@@ -25,15 +28,19 @@ USAGE
   $ apollo COMMAND
 ...
 ```
+
 <!-- usagestop -->
+
 # Commands
+
 <!-- commands -->
-* [`apollo codegen:generate [OUTPUT]`](#apollo-codegengenerate-output)
-* [`apollo help [COMMAND]`](#apollo-help-command)
-* [`apollo schema:check`](#apollo-schemacheck)
-* [`apollo schema:checkQueries`](#apollo-schemacheck-queries)
-* [`apollo schema:download OUTPUT`](#apollo-schemadownload-output)
-* [`apollo schema:publish`](#apollo-schemapublish)
+
+- [`apollo codegen:generate [OUTPUT]`](#apollo-codegengenerate-output)
+- [`apollo help [COMMAND]`](#apollo-help-command)
+- [`apollo schema:check`](#apollo-schemacheck)
+- [`apollo schema:checkQueries`](#apollo-schemacheck-queries)
+- [`apollo schema:download OUTPUT`](#apollo-schemadownload-output)
+- [`apollo schema:publish`](#apollo-schemapublish)
 
 ## `apollo codegen:generate [OUTPUT]`
 
@@ -174,13 +181,17 @@ OPTIONS
 ```
 
 _See code: [src/commands/schema/publish.ts](https://github.com/apollographql/apollo-cli/blob/v1.1.1/src/commands/schema/publish.ts)_
+
 <!-- commandsstop -->
 
 # Code Generation
+
 ## Accompanying Libraries
+
 See [Apollo iOS](https://github.com/apollographql/apollo-ios) for details on the mapping from GraphQL results to Swift types, as well as runtime support for executing queries and mutations. For Scala, see [React Apollo Scala.js](https://github.com/apollographql/react-apollo-scalajs) for details on how to use generated Scala code in a Scala.js app with Apollo Client.
 
 ## `gql` template support
+
 If the source file for generation is a JavaScript or TypeScript file, the codegen will try to extrapolate the queries inside the [gql tag](https://github.com/apollographql/graphql-tag) templates.
 
 The tag name is configurable using the CLI `--tagName` option.
@@ -191,11 +202,13 @@ When using the codegen command with Typescript or Flow, make sure to add the `__
 
 If you're using a client like `apollo-client` that does this automatically for your GraphQL operations, pass in the `--addTypename` option to `apollo codegen:generate` to make sure the generated Typescript and Flow types have the `__typename` field as well. This is required to ensure proper type generation support for `GraphQLUnionType` and `GraphQLInterfaceType` fields.
 
-## Why is the __typename field required?
+## Why is the \_\_typename field required?
+
 Using the type information from the GraphQL schema, we can infer the possible types for fields. However, in the case of a `GraphQLUnionType` or `GraphQLInterfaceType`, there are multiple types that are possible for that field. This is best modeled using a disjoint union with the `__typename`
 as the discriminant.
 
 For example, given a schema:
+
 ```graphql
 ...
 
@@ -239,16 +252,19 @@ Apollo Codegen will generate a union type for Character.
 
 ```javascript
 export type CharactersQuery = {
-  characters: Array<{
-    __typename: 'Human',
-    name: string,
-    homePlanet: ?string
-  } | {
-    __typename: 'Droid',
-    name: string,
-    primaryFunction: ?string
-  }>
-}
+  characters: Array<
+    | {
+        __typename: "Human",
+        name: string,
+        homePlanet: ?string
+      }
+    | {
+        __typename: "Droid",
+        name: string,
+        primaryFunction: ?string
+      }
+  >
+};
 ```
 
 This type can then be used as follows to ensure that all possible types are handled:
@@ -256,17 +272,28 @@ This type can then be used as follows to ensure that all possible types are hand
 ```javascript
 function CharacterFigures({ characters }: CharactersQuery) {
   return characters.map(character => {
-    switch(character.__typename) {
+    switch (character.__typename) {
       case "Human":
-        return <HumanFigure homePlanet={character.homePlanet} name={character.name} />
+        return (
+          <HumanFigure
+            homePlanet={character.homePlanet}
+            name={character.name}
+          />
+        );
       case "Droid":
-        return <DroidFigure primaryFunction={character.primaryFunction} name={character.name} />
+        return (
+          <DroidFigure
+            primaryFunction={character.primaryFunction}
+            name={character.name}
+          />
+        );
     }
   });
 }
 ```
 
 # Contributing
+
 [![Build status](https://travis-ci.org/apollographql/apollo-cli.svg?branch=master)](https://travis-ci.org/apollographql/apollo-cli)
 
 This repo is composed of multiple packages managed by Lerna. The `apollo-cli` contains the core CLI commands. The `apollo-codegen-core` package contains all the compiler APIs needed to implement code generation support for new languages. The other `apollo-codegen-*` packages implement code generation support for individual languages.
@@ -279,3 +306,7 @@ npm test
 ```
 
 You can also run `npm` commands within package folders after you have bootstrapped the repository (part of `npm install`).
+
+```
+
+```

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -51,39 +51,24 @@ USAGE
   $ apollo codegen:generate [OUTPUT]
 
 ARGUMENTS
-  OUTPUT  Path to write the generated code to. Can be a directory to generate split files (TypeScript/Flow only). Leave
-          empty to generate types next to sources (TypeScript/Flow only)
+  OUTPUT  Path to write the generated code to. Can be a directory to generate split files (TypeScript/Flow only). Leave empty to generate types next to sources (TypeScript/Flow only)
 
 OPTIONS
   -h, --help                                 Show command help
   --addTypename                              Automatically add __typename to your queries
   --customScalarsPrefix=customScalarsPrefix  Include a prefix when using provided types for custom scalars
   --key=key                                  The API key for the Apollo Engine service
+  --localDirectory=localDirectory            Put each generated file in a directory next to its source file (TypeScript/Flow only). Ignored if `output` is set.
   --mergeInFieldsFromFragmentSpreads         Merge fragment fields onto its enclosing type
   --namespace=namespace                      The namespace to emit generated code into.
-
-  --only=only                                Parse all input files, but only output generated code for the specified
-                                             file [Swift only]
-
-  --operationIdsPath=operationIdsPath        Path to an operation id JSON map file. If specified, also stores the
-                                             operation ids (hashes) as properties on operation types [currently
-                                             Swift-only]
-
+  --only=only                                Parse all input files, but only output generated code for the specified file [Swift only]
+  --operationIdsPath=operationIdsPath        Path to an operation id JSON map file. If specified, also stores the operation ids (hashes) as properties on operation types [currently Swift-only]
   --passthroughCustomScalars                 Use your own types for custom scalars
-
-  --queries=queries                          [default: **/*.graphql] Path to your GraphQL queries, can include search
-                                             tokens like **
-
+  --queries=queries                          [default: **/*.graphql] Path to your GraphQL queries, can include search tokens like **
   --schema=schema                            Path to your GraphQL schema introspection result
-
-  --tagName=tagName                          [default: gql] Name of the template literal tag used to identify template
-                                             literals containing GraphQL queries in Javascript/Typescript code
-
-  --target=target                            Type of code generator to use (swift | typescript | flow | scala), inferred
-                                             from output
-
+  --tagName=tagName                          [default: gql] Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code
+  --target=target                            Type of code generator to use (swift | typescript | flow | scala), inferred from output
   --useFlowExactObjects                      Use Flow read only types for generated types [flow only]
-
   --useFlowReadOnlyTypes                     Use Flow read only types for generated types [flow only]
 ```
 

--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -51,25 +51,80 @@ USAGE
   $ apollo codegen:generate [OUTPUT]
 
 ARGUMENTS
-  OUTPUT  Path to write the generated code to. Can be a directory to generate split files (TypeScript/Flow only). Leave empty to generate types next to sources (TypeScript/Flow only)
+  OUTPUT
+      Directory to which generated files will be written.
+      - For TypeScript/Flow generators, this specifies a directory relative
+      to each source file by default.
+      - For TypeScript/Flow generators with the "outputRelativeToCWD" flag
+      is set, and for the Swift generator, this specifies a file or
+      directory (absolute or relative to the current working directory) to
+      which:
+        - a file will be written for each query (if "output" is a
+      directory)
+        - all generated types will be written
+      - For all other types, this defines a file (absolute or relative to
+      the current working directory) to which all generated types are
+      written.
 
 OPTIONS
-  -h, --help                                 Show command help
-  --addTypename                              Automatically add __typename to your queries
-  --customScalarsPrefix=customScalarsPrefix  Include a prefix when using provided types for custom scalars
-  --key=key                                  The API key for the Apollo Engine service
-  --localDirectory=localDirectory            Put each generated file in a directory next to its source file (TypeScript/Flow only). Ignored if `output` is set.
-  --mergeInFieldsFromFragmentSpreads         Merge fragment fields onto its enclosing type
-  --namespace=namespace                      The namespace to emit generated code into.
-  --only=only                                Parse all input files, but only output generated code for the specified file [Swift only]
-  --operationIdsPath=operationIdsPath        Path to an operation id JSON map file. If specified, also stores the operation ids (hashes) as properties on operation types [currently Swift-only]
-  --passthroughCustomScalars                 Use your own types for custom scalars
-  --queries=queries                          [default: **/*.graphql] Path to your GraphQL queries, can include search tokens like **
-  --schema=schema                            Path to your GraphQL schema introspection result
-  --tagName=tagName                          [default: gql] Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code
-  --target=target                            Type of code generator to use (swift | typescript | flow | scala), inferred from output
-  --useFlowExactObjects                      Use Flow read only types for generated types [flow only]
-  --useFlowReadOnlyTypes                     Use Flow read only types for generated types [flow only]
+  -h, --help
+      Show command help
+
+  --addTypename
+      Automatically add __typename to your queries
+
+  --customScalarsPrefix=customScalarsPrefix
+      Include a prefix when using provided types for custom scalars
+
+  --key=key
+      The API key for the Apollo Engine service
+
+  --mergeInFieldsFromFragmentSpreads
+      Merge fragment fields onto its enclosing type
+
+  --namespace=namespace
+      The namespace to emit generated code into.
+
+  --only=only
+      Parse all input files, but only output generated code for the
+      specified file [Swift only]
+
+  --operationIdsPath=operationIdsPath
+      Path to an operation id JSON map file. If specified, also stores the
+      operation ids (hashes) as properties on operation types [currently
+      Swift-only]
+
+  --outputRelativeToCWD
+      By default, TypeScript/Flow will put each generated file in a
+      directory next to its source file using the value of the "output" as
+      the directory name. Set "outputRelativeToCWD" to put all generated
+      files in the directory relative to the current working directory
+      defined by "output".
+
+  --passthroughCustomScalars
+      Use your own types for custom scalars
+
+  --queries=queries
+      [default: **/*.graphql] Path to your GraphQL queries, can include
+      search tokens like **
+
+  --schema=schema
+      Path to your GraphQL schema introspection result
+
+  --tagName=tagName
+      [default: gql] Name of the template literal tag used to identify
+      template literals containing GraphQL queries in Javascript/Typescript
+      code
+
+  --target=target
+      Type of code generator to use (swift | typescript | flow | scala),
+      inferred from output
+
+  --useFlowExactObjects
+      Use Flow read only types for generated types [flow only]
+
+  --useFlowReadOnlyTypes
+      Use Flow read only types for generated types [flow only]
 ```
 
 _See code: [src/commands/codegen/generate.ts](https://github.com/apollographql/apollo-cli/blob/v1.1.1/src/commands/codegen/generate.ts)_

--- a/packages/apollo-cli/package.json
+++ b/packages/apollo-cli/package.json
@@ -68,7 +68,6 @@
     "memfs": "^2.9.1",
     "fs-monkey": "^0.3.3"
   },
-  "precommit": "pretty-quick --staged",
   "engines": {
     "node": ">=8.0.0"
   },
@@ -119,6 +118,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tsc -p . --noEmit",
     "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme",
+    "precommit": "pretty-quick --staged",
     "test": "jest",
     "version": "oclif-dev readme && git add README.md"
   },

--- a/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
@@ -176,7 +176,61 @@ export type SimpleQuery = {
 //=============================================================="
 `;
 
+exports[`successful codegen writes Flow types to a custom directory next to sources when no output is set and directory is set 1`] = `
+"
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export type SimpleQuery = {
+  hello: string
+};
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
 exports[`successful codegen writes TypeScript types next to sources when no output is set 1`] = `
+"
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`successful codegen writes TypeScript types to a custom directory next to sources when no output is set and directory is set 1`] = `
 "
 
 /* tslint:disable */

--- a/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
@@ -148,7 +148,7 @@ export interface SimpleQuery {
 //=============================================================="
 `;
 
-exports[`successful codegen writes Flow types next to sources when no output is set 1`] = `
+exports[`successful codegen writes Flow types into a __generated__ directory next to sources when no output is set 1`] = `
 "
 
 /* @flow */
@@ -176,7 +176,7 @@ export type SimpleQuery = {
 //=============================================================="
 `;
 
-exports[`successful codegen writes Flow types to a custom directory next to sources when no output is set and directory is set 1`] = `
+exports[`successful codegen writes Flow types next to sources when output is set to empty string 1`] = `
 "
 
 /* @flow */
@@ -204,7 +204,35 @@ export type SimpleQuery = {
 //=============================================================="
 `;
 
-exports[`successful codegen writes TypeScript types next to sources when no output is set 1`] = `
+exports[`successful codegen writes Flow types to a custom directory next to sources when output is set 1`] = `
+"
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export type SimpleQuery = {
+  hello: string
+};
+
+/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`successful codegen writes TypeScript types into a __generated__ directory next to sources when no output is set 1`] = `
 "
 
 /* tslint:disable */
@@ -230,7 +258,33 @@ export interface SimpleQuery {
 //=============================================================="
 `;
 
-exports[`successful codegen writes TypeScript types to a custom directory next to sources when no output is set and directory is set 1`] = `
+exports[`successful codegen writes TypeScript types next to sources when output is set to empty string 1`] = `
+"
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`successful codegen writes TypeScript types to a custom directory next to sources when output is set 1`] = `
 "
 
 /* tslint:disable */

--- a/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
@@ -149,6 +149,68 @@ describe("successful codegen", () => {
         mockFS.readFileSync("directory/SimpleQuery.js").toString()
       ).toMatchSnapshot();
     });
+
+  test
+    .do(() => {
+      vol.fromJSON({
+        "schema.json": JSON.stringify(fullSchema.__schema),
+        "directory/component.tsx": `
+          gql\`
+            query SimpleQuery {
+              hello
+            }
+          \`;
+        `
+      });
+    })
+    .command([
+      "codegen:generate",
+      "--schema=schema.json",
+      "--queries=**/*.tsx",
+      "--target=typescript",
+      "--localDirectory=__generated__"
+    ])
+    .it(
+      "writes TypeScript types to a custom directory next to sources when no output is set and directory is set",
+      () => {
+        expect(
+          mockFS
+            .readFileSync("directory/__generated__/SimpleQuery.ts")
+            .toString()
+        ).toMatchSnapshot();
+      }
+    );
+
+  test
+    .do(() => {
+      vol.fromJSON({
+        "schema.json": JSON.stringify(fullSchema.__schema),
+        "directory/component.jsx": `
+          gql\`
+            query SimpleQuery {
+              hello
+            }
+          \`;
+        `
+      });
+    })
+    .command([
+      "codegen:generate",
+      "--schema=schema.json",
+      "--queries=**/*.jsx",
+      "--target=flow",
+      "--localDirectory=__generated__"
+    ])
+    .it(
+      "writes Flow types to a custom directory next to sources when no output is set and directory is set",
+      () => {
+        expect(
+          mockFS
+            .readFileSync("directory/__generated__/SimpleQuery.js")
+            .toString()
+        ).toMatchSnapshot();
+      }
+    );
 });
 
 describe("error handling", () => {

--- a/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
@@ -69,7 +69,7 @@ describe("successful codegen", () => {
         "queryOne.graphql": simpleQuery.toString()
       });
     })
-    .command(["codegen:generate", "--schema=schema.json", "--outputRelativeToCWD", "API.ts"])
+    .command(["codegen:generate", "--schema=schema.json", "--outputFlat", "API.ts"])
     .it("infers TypeScript target and writes types", () => {
       expect(mockFS.readFileSync("API.ts").toString()).toMatchSnapshot();
     });
@@ -81,7 +81,7 @@ describe("successful codegen", () => {
         "queryOne.graphql": simpleQuery.toString()
       });
     })
-    .command(["codegen:generate", "--schema=schema.json", "--outputRelativeToCWD", "API.js"])
+    .command(["codegen:generate", "--schema=schema.json", "--outputFlat", "API.js"])
     .it("infers Flow target and writes types", () => {
       expect(mockFS.readFileSync("API.js").toString()).toMatchSnapshot();
     });

--- a/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
@@ -1,9 +1,6 @@
-jest.mock(
-  "apollo-codegen-core/lib/localfs",
-  () => {
-    return require("../../../__mocks__/localfs");
-  }
-);
+jest.mock("apollo-codegen-core/lib/localfs", () => {
+  return require("../../../__mocks__/localfs");
+});
 
 // this is because of herkou-cli-utils hacky mocking system on their console logger
 import { stdout, mockConsole } from "heroku-cli-util";
@@ -17,21 +14,26 @@ import { fs as mockFS, vol } from "apollo-codegen-core/lib/localfs";
 const test = setup.do(() => mockConsole());
 const fullSchema = execute(
   buildSchema(
-    fs.readFileSync(path.resolve(__dirname, "../../schema/__tests__/fixtures/schema.graphql"), {
-      encoding: "utf-8",
-    })
+    fs.readFileSync(
+      path.resolve(__dirname, "../../schema/__tests__/fixtures/schema.graphql"),
+      {
+        encoding: "utf-8"
+      }
+    )
   ),
   gql(introspectionQuery)
 ).data;
 
-const simpleQuery = fs.readFileSync(path.resolve(__dirname, "./fixtures/simpleQuery.graphql"));
+const simpleQuery = fs.readFileSync(
+  path.resolve(__dirname, "./fixtures/simpleQuery.graphql")
+);
 
 beforeEach(() => {
   vol.reset();
   vol.fromJSON({
-    "__blankFileSoDirectoryExists": ""
+    __blankFileSoDirectoryExists: ""
   });
-})
+});
 
 jest.setTimeout(15000);
 
@@ -93,7 +95,9 @@ describe("successful codegen", () => {
     })
     .command(["codegen:generate", "--schema=schema.json", "operations.json"])
     .it("infers JSON target and writes operations", () => {
-      expect(mockFS.readFileSync("operations.json").toString()).toMatchSnapshot();
+      expect(
+        mockFS.readFileSync("operations.json").toString()
+      ).toMatchSnapshot();
     });
 
   test
@@ -109,9 +113,16 @@ describe("successful codegen", () => {
         `
       });
     })
-    .command(["codegen:generate", "--schema=schema.json", "--queries=**/*.tsx", "--target=typescript"])
+    .command([
+      "codegen:generate",
+      "--schema=schema.json",
+      "--queries=**/*.tsx",
+      "--target=typescript"
+    ])
     .it("writes TypeScript types next to sources when no output is set", () => {
-      expect(mockFS.readFileSync("directory/SimpleQuery.ts").toString()).toMatchSnapshot();
+      expect(
+        mockFS.readFileSync("directory/SimpleQuery.ts").toString()
+      ).toMatchSnapshot();
     });
 
   test
@@ -127,9 +138,16 @@ describe("successful codegen", () => {
         `
       });
     })
-    .command(["codegen:generate", "--schema=schema.json", "--queries=**/*.jsx", "--target=flow"])
+    .command([
+      "codegen:generate",
+      "--schema=schema.json",
+      "--queries=**/*.jsx",
+      "--target=flow"
+    ])
     .it("writes Flow types next to sources when no output is set", () => {
-      expect(mockFS.readFileSync("directory/SimpleQuery.js").toString()).toMatchSnapshot();
+      expect(
+        mockFS.readFileSync("directory/SimpleQuery.js").toString()
+      ).toMatchSnapshot();
     });
 });
 
@@ -141,6 +159,8 @@ describe("error handling", () => {
 
   test
     .command(["codegen:generate", "--target=swift"])
-    .catch(err => expect(err.message).toMatch(/The output path must be specified/))
+    .catch(err =>
+      expect(err.message).toMatch(/The output path must be specified/)
+    )
     .it("errors when no output file is provided");
 });

--- a/packages/apollo-cli/src/commands/codegen/generate.ts
+++ b/packages/apollo-cli/src/commands/codegen/generate.ts
@@ -73,7 +73,11 @@ export default class Generate extends Command {
       description:
         "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
       default: "gql"
-    })
+    }),
+    localDirectory: flags.string({
+      description:
+        "Put each generated file in a directory next to its source file (TypeScript/Flow only). Ignored if `output` is set."
+    }),
   };
 
   static args = [
@@ -189,6 +193,7 @@ export default class Generate extends Command {
         title: "Generating query files",
         task: async (ctx, task) => {
           task.title = `Generating query files with '${inferredTarget}' target`;
+
           const writtenFiles = generate(
             ctx.queryPaths,
             ctx.schema,
@@ -196,7 +201,7 @@ export default class Generate extends Command {
             flags.only ? path.resolve(flags.only) : "",
             inferredTarget,
             flags.tagName as string,
-            !args.output,
+            args.output ? false : flags.localDirectory || true,
             {
               passthroughCustomScalars:
                 flags.passthroughCustomScalars || flags.customScalarsPrefix,

--- a/packages/apollo-cli/src/commands/codegen/generate.ts
+++ b/packages/apollo-cli/src/commands/codegen/generate.ts
@@ -74,9 +74,9 @@ export default class Generate extends Command {
         "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
       default: "gql"
     }),
-    outputRelativeToCWD: flags.boolean({
+    outputFlat: flags.boolean({
       description:
-        'By default, TypeScript/Flow will put each generated file in a directory next to its source file using the value of the "output" as the directory name. Set "outputRelativeToCWD" to put all generated files in the directory relative to the current working directory defined by "output".'
+        'By default, TypeScript/Flow will put each generated file in a directory next to its source file using the value of the "output" as the directory name. Set "outputFlat" to put all generated files in the directory relative to the current working directory defined by "output".'
     })
   };
 
@@ -85,7 +85,7 @@ export default class Generate extends Command {
       name: "output",
       description: `Directory to which generated files will be written.
 - For TypeScript/Flow generators, this specifies a directory relative to each source file by default.
-- For TypeScript/Flow generators with the "outputRelativeToCWD" flag is set, and for the Swift generator, this specifies a file or directory (absolute or relative to the current working directory) to which:
+- For TypeScript/Flow generators with the "outputFlat" flag is set, and for the Swift generator, this specifies a file or directory (absolute or relative to the current working directory) to which:
   - a file will be written for each query (if "output" is a directory)
   - all generated types will be written
 - For all other types, this defines a file (absolute or relative to the current working directory) to which all generated types are written.`
@@ -154,12 +154,12 @@ export default class Generate extends Command {
     }
 
     if (
-      !flags.outputRelativeToCWD &&
+      !flags.outputFlat &&
       (inferredTarget === "typescript" || inferredTarget === "flow") &&
       (args.output && (path.isAbsolute(args.output) || args.output.split(path.sep).length > 1))
     ) {
       this.error(
-        "For TypeScript and Flow generators, \"output\" must be empty or a single directory name, unless the \"outputRelativeToCWD\" flag is set."
+        "For TypeScript and Flow generators, \"output\" must be empty or a single directory name, unless the \"outputFlat\" flag is set."
       );
       return;
     }
@@ -215,7 +215,7 @@ export default class Generate extends Command {
             flags.only ? path.resolve(flags.only) : "",
             inferredTarget,
             flags.tagName as string,
-            !flags.outputRelativeToCWD,
+            !flags.outputFlat,
             {
               passthroughCustomScalars:
                 flags.passthroughCustomScalars || flags.customScalarsPrefix,

--- a/packages/apollo-cli/src/generate.ts
+++ b/packages/apollo-cli/src/generate.ts
@@ -75,21 +75,9 @@ export default function generate(
       [fileName: string]: BasicGeneratedFile;
     } = {};
 
-    const outputIndividualFiles =
-      fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
-
-    if (outputIndividualFiles) {
+    if (nextToSources) {
       generatedFiles.forEach(({ sourcePath, fileName, content }) => {
-        if (nextToSources === true) {
-          outFiles[path.join(path.dirname(sourcePath), fileName)] = {
-            output: content.fileContents + common
-          };
-
-          return;
-        }
-
-        if (typeof nextToSources === "string") {
-          const dir = path.join(path.dirname(sourcePath), nextToSources);
+          const dir = path.join(path.dirname(sourcePath), outputPath);
 
           if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir);
@@ -98,10 +86,15 @@ export default function generate(
           outFiles[path.join(dir, fileName)] = {
             output: content.fileContents + common
           };
+      });
 
-          return;
-        }
+      writeGeneratedFiles(outFiles, path.resolve("."));
 
+      writtenFiles += Object.keys(outFiles).length;
+    }
+
+    else if (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
+      generatedFiles.forEach(({ sourcePath, fileName, content }) => {
         outFiles[fileName] = {
           output: content.fileContents + common
         };
@@ -110,7 +103,9 @@ export default function generate(
       writeGeneratedFiles(outFiles, outputPath);
 
       writtenFiles += Object.keys(outFiles).length;
-    } else {
+    }
+
+    else {
       fs.writeFileSync(
         outputPath,
         generatedFiles.map(o => o.content.fileContents).join("\n") + common

--- a/packages/apollo-cli/src/generate.ts
+++ b/packages/apollo-cli/src/generate.ts
@@ -34,7 +34,7 @@ export default function generate(
   only: string,
   target: TargetType,
   tagName: string,
-  nextToSources: boolean,
+  nextToSources: boolean | string,
   options: any
 ): number {
   let writtenFiles = 0;
@@ -80,9 +80,29 @@ export default function generate(
 
     if (outputIndividualFiles) {
       generatedFiles.forEach(({ sourcePath, fileName, content }) => {
-        outFiles[
-          nextToSources ? `${path.dirname(sourcePath)}/${fileName}` : fileName
-        ] = {
+        if (nextToSources === true) {
+          outFiles[path.join(path.dirname(sourcePath), fileName)] = {
+            output: content.fileContents + common
+          };
+
+          return;
+        }
+
+        if (typeof nextToSources === "string") {
+          const dir = path.join(path.dirname(sourcePath), nextToSources);
+
+          if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+          }
+
+          outFiles[path.join(dir, fileName)] = {
+            output: content.fileContents + common
+          };
+
+          return;
+        }
+
+        outFiles[fileName] = {
           output: content.fileContents + common
         };
       });

--- a/packages/apollo-cli/src/generate.ts
+++ b/packages/apollo-cli/src/generate.ts
@@ -1,24 +1,31 @@
 import { fs } from "apollo-codegen-core/lib/localfs";
-import * as path from 'path';
+import * as path from "path";
 
-import { loadAndMergeQueryDocuments } from 'apollo-codegen-core/lib/loading';
-import { validateQueryDocument } from './validation';
-import { compileToIR } from 'apollo-codegen-core/lib/compiler';
-import { compileToLegacyIR } from 'apollo-codegen-core/lib/compiler/legacyIR';
-import serializeToJSON from 'apollo-codegen-core/lib/serializeToJSON';
-import { BasicGeneratedFile } from 'apollo-codegen-core/lib/utilities/CodeGenerator'
+import { loadAndMergeQueryDocuments } from "apollo-codegen-core/lib/loading";
+import { validateQueryDocument } from "./validation";
+import { compileToIR } from "apollo-codegen-core/lib/compiler";
+import { compileToLegacyIR } from "apollo-codegen-core/lib/compiler/legacyIR";
+import serializeToJSON from "apollo-codegen-core/lib/serializeToJSON";
+import { BasicGeneratedFile } from "apollo-codegen-core/lib/utilities/CodeGenerator";
 
-import { generateSource as generateSwiftSource } from 'apollo-codegen-swift';
-import { generateSource as generateTypescriptLegacySource } from 'apollo-codegen-typescript-legacy';
-import { generateSource as generateFlowLegacySource } from 'apollo-codegen-flow-legacy';
-import { generateSource as generateFlowSource } from 'apollo-codegen-flow';
-import { generateSource as generateTypescriptSource } from 'apollo-codegen-typescript';
-import { generateSource as generateScalaSource } from 'apollo-codegen-scala';
-import { GraphQLSchema } from 'graphql';
+import { generateSource as generateSwiftSource } from "apollo-codegen-swift";
+import { generateSource as generateTypescriptLegacySource } from "apollo-codegen-typescript-legacy";
+import { generateSource as generateFlowLegacySource } from "apollo-codegen-flow-legacy";
+import { generateSource as generateFlowSource } from "apollo-codegen-flow";
+import { generateSource as generateTypescriptSource } from "apollo-codegen-typescript";
+import { generateSource as generateScalaSource } from "apollo-codegen-scala";
+import { GraphQLSchema } from "graphql";
 
-export type TargetType = 'json' | 'swift' | 'ts-legacy' | 'typescript-legacy'
-  | 'flow-legacy' | 'scala' | 'flow' | 'typescript'
-  | 'ts';
+export type TargetType =
+  | "json"
+  | "swift"
+  | "ts-legacy"
+  | "typescript-legacy"
+  | "flow-legacy"
+  | "scala"
+  | "flow"
+  | "typescript"
+  | "ts";
 
 export default function generate(
   inputPaths: string[],
@@ -36,11 +43,12 @@ export default function generate(
 
   validateQueryDocument(schema, document);
 
-  if (target === 'swift') {
+  if (target === "swift") {
     options.addTypename = true;
     const context = compileToIR(schema, document, options);
 
-    const outputIndividualFiles = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
+    const outputIndividualFiles =
+      fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
     const generator = generateSwiftSource(context, outputIndividualFiles, only);
 
@@ -56,30 +64,30 @@ export default function generate(
       writeOperationIdsMap(context);
       writtenFiles += 1;
     }
-  }
-  else if (target === 'flow' || target === 'typescript' || target === 'ts') {
+  } else if (target === "flow" || target === "typescript" || target === "ts") {
     const context = compileToIR(schema, document, options);
-    const { generatedFiles, common } = target === 'flow'
-      ? generateFlowSource(context)
-      : generateTypescriptSource(context) ;
+    const { generatedFiles, common } =
+      target === "flow"
+        ? generateFlowSource(context)
+        : generateTypescriptSource(context);
 
     const outFiles: {
-      [fileName: string]: BasicGeneratedFile
+      [fileName: string]: BasicGeneratedFile;
     } = {};
 
-    const outputIndividualFiles = fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
+    const outputIndividualFiles =
+      fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
     if (outputIndividualFiles) {
-      generatedFiles.forEach(({sourcePath, fileName, content}) => {
-        outFiles[nextToSources ? `${path.dirname(sourcePath)}/${fileName}` : fileName] = {
+      generatedFiles.forEach(({ sourcePath, fileName, content }) => {
+        outFiles[
+          nextToSources ? `${path.dirname(sourcePath)}/${fileName}` : fileName
+        ] = {
           output: content.fileContents + common
-        }
+        };
       });
 
-      writeGeneratedFiles(
-        outFiles,
-        outputPath
-      );
+      writeGeneratedFiles(outFiles, outputPath);
 
       writtenFiles += Object.keys(outFiles).length;
     } else {
@@ -90,22 +98,21 @@ export default function generate(
 
       writtenFiles += 1;
     }
-  }
-  else {
+  } else {
     let output;
     const context = compileToLegacyIR(schema, document, options);
     switch (target) {
-      case 'json':
+      case "json":
         output = serializeToJSON(context);
         break;
-      case 'ts-legacy':
-      case 'typescript-legacy':
+      case "ts-legacy":
+      case "typescript-legacy":
         output = generateTypescriptLegacySource(context);
         break;
-      case 'flow-legacy':
+      case "flow-legacy":
         output = generateFlowLegacySource(context);
         break;
-      case 'scala':
+      case "scala":
         output = generateScalaSource(context);
     }
 
@@ -125,7 +132,10 @@ function writeGeneratedFiles(
   outputDirectory: string
 ) {
   for (const [fileName, generatedFile] of Object.entries(generatedFiles)) {
-    fs.writeFileSync(path.join(outputDirectory, fileName), generatedFile.output);
+    fs.writeFileSync(
+      path.join(outputDirectory, fileName),
+      generatedFile.output
+    );
   }
 }
 
@@ -136,11 +146,16 @@ interface OperationIdsMap {
 
 function writeOperationIdsMap(context: any) {
   let operationIdsMap: { [id: string]: OperationIdsMap } = {};
-  Object.keys(context.operations).map(k => context.operations[k]).forEach(operation => {
-    operationIdsMap[operation.operationId] = {
-      name: operation.operationName,
-      source: operation.sourceWithFragments
-    };
-  });
-  fs.writeFileSync(context.options.operationIdsPath, JSON.stringify(operationIdsMap, null, 2));
+  Object.keys(context.operations)
+    .map(k => context.operations[k])
+    .forEach(operation => {
+      operationIdsMap[operation.operationId] = {
+        name: operation.operationName,
+        source: operation.sourceWithFragments
+      };
+    });
+  fs.writeFileSync(
+    context.options.operationIdsPath,
+    JSON.stringify(operationIdsMap, null, 2)
+  );
 }


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Fixes #469. Before the change from `apollo-codegen` to `apollo` cli, flow type definitions were output into a `__generated__` directory, next to their respective source files.

This adds a `localDirectory` flag that accepts a name to use locally for generated types. For example:

```sh
apollo generate:flow **/*.graphql --localDirectory=__generated__
```

This flag is ignored if `--output` is specified.