### PR TITLE
added clarity to schema:download

### DIFF
--- a/packages/apollo-cli/README.md
+++ b/packages/apollo-cli/README.md
@@ -150,10 +150,11 @@ ARGUMENTS
 
 OPTIONS
   -h, --help           Show command help
-  --endpoint=endpoint  [default: http://localhost:4000/graphql] The URL of the server to fetch the schema from
+  --endpoint=endpoint  [default: http://localhost:4000/graphql] The URL of the server to fetch the schema from or path to ./your/local/schema.graphql
   --header=header      Additional headers to send to server for introspectionQuery
   --key=key            The API key for the Apollo Engine service
 ```
+Note: This replaces `apollo-codegen introspect-schema`.
 
 _See code: [src/commands/schema/download.ts](https://github.com/apollographql/apollo-cli/blob/v1.1.1/src/commands/schema/download.ts)_
 

--- a/packages/apollo-cli/src/commands/schema/download.ts
+++ b/packages/apollo-cli/src/commands/schema/download.ts
@@ -28,7 +28,7 @@ export default class SchemaDownload extends Command {
         "Additional headers to send to server for introspectionQuery",
     }),
     endpoint: flags.string({
-      description: "The URL of the server to fetch the schema from",
+      description: "The URL of the server to fetch the schema from or path to ./your/local/schema.graphql",
       default: "http://localhost:4000/graphql", // apollo-server 2.0 default address
     }),
 


### PR DESCRIPTION
Hopefully less pain moving from apollo-codegen.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->