### PR TITLE
Stop default flag values from overriding custom config

### DIFF
--- a/packages/apollo-cli/src/load-config.ts
+++ b/packages/apollo-cli/src/load-config.ts
@@ -59,7 +59,7 @@ export function loadConfigStep(
         };
       }
 
-      if (flags.queries) {
+      if (!ctx.config.queries || ctx.config.queries.length == 0 && flags.queries) {
         ctx.config.queries = [
           {
             schema: "default",
@@ -67,6 +67,13 @@ export function loadConfigStep(
             excludes: []
           }
         ];
+      }
+      else if (flags.queries && flags.queries != '**/*.graphql') {
+        ctx.config.queries = ctx.config.queries.map((query: any) => {
+          return Object.assign({}, query, {
+            includes: flags.queries.split("\n")
+          })
+        })
       }
 
       if (flags.key) {


### PR DESCRIPTION
* Check if a custom config for queries hasn't been setup, else fallback to flags.queries


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

/label bugfix

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->