### PR TITLE
[typescript] Only output comment for input if there is one

### DIFF
--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -81,10 +81,12 @@ export default class TypescriptGenerator {
       keyInheritsNullability: true
     }), []);
 
-    inputType.leadingComments = [{
-      type: 'CommentBlock',
-      value: commentBlockContent(description || "")
-    } as t.CommentBlock]
+    if (description) {
+      inputType.leadingComments = [{
+        type: 'CommentBlock',
+        value: commentBlockContent(description)
+      } as t.CommentBlock]
+    }
 
     return inputType;
   }


### PR DESCRIPTION
Only output comment for input if there is one, this is aligned with how enums are generated: https://github.com/apollographql/apollo-cli/blob/master/packages/apollo-codegen-typescript/src/language.ts#L57-L62