### PR TITLE
[TS] Dedup enums and inputs by using global types file

### DIFF
--- a/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
@@ -592,7 +592,11 @@ exports[`successful codegen writes TypeScript types into a __generated__ directo
 
 export interface SimpleQuery {
   hello: string;
-}
+}"
+`;
+
+exports[`successful codegen writes TypeScript types into a __generated__ directory next to sources when no output is set 2`] = `
+"
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -618,7 +622,11 @@ exports[`successful codegen writes TypeScript types next to sources when output 
 
 export interface SimpleQuery {
   hello: string;
-}
+}"
+`;
+
+exports[`successful codegen writes TypeScript types next to sources when output is set to empty string 2`] = `
+"
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
@@ -644,7 +652,11 @@ exports[`successful codegen writes TypeScript types to a custom directory next t
 
 export interface SimpleQuery {
   hello: string;
-}
+}"
+`;
+
+exports[`successful codegen writes TypeScript types to a custom directory next to sources when output is set 2`] = `
+"
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.

--- a/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
+++ b/packages/apollo-cli/src/commands/codegen/__tests__/generate.test.ts
@@ -325,6 +325,9 @@ describe("successful codegen", () => {
       expect(
         mockFS.readFileSync("directory/__generated__/SimpleQuery.ts").toString()
       ).toMatchSnapshot();
+      expect(
+        mockFS.readFileSync("__generated__/globalTypes.ts").toString()
+      ).toMatchSnapshot();
     });
 
   test
@@ -379,6 +382,9 @@ describe("successful codegen", () => {
           mockFS
             .readFileSync("directory/__foo__/SimpleQuery.ts")
             .toString()
+        ).toMatchSnapshot();
+        expect(
+          mockFS.readFileSync("__foo__/globalTypes.ts").toString()
         ).toMatchSnapshot();
       }
     );
@@ -441,6 +447,9 @@ describe("successful codegen", () => {
             mockFS
               .readFileSync("directory/SimpleQuery.ts")
               .toString()
+          ).toMatchSnapshot();
+          expect(
+            mockFS.readFileSync("globalTypes.ts").toString()
           ).toMatchSnapshot();
         }
       );

--- a/packages/apollo-cli/src/generate.ts
+++ b/packages/apollo-cli/src/generate.ts
@@ -12,7 +12,7 @@ import { generateSource as generateSwiftSource } from "apollo-codegen-swift";
 import { generateSource as generateTypescriptLegacySource } from "apollo-codegen-typescript-legacy";
 import { generateSource as generateFlowLegacySource } from "apollo-codegen-flow-legacy";
 import { generateSource as generateFlowSource } from "apollo-codegen-flow";
-import { generateSource as generateTypescriptSource } from "apollo-codegen-typescript";
+import { generateLocalSource as generateTypescriptLocalSource, generateGlobalSource as generateTypescriptGlobalSource } from "apollo-codegen-typescript";
 import { generateSource as generateScalaSource } from "apollo-codegen-scala";
 import { GraphQLSchema } from "graphql";
 import { FlowCompilerOptions } from '../../apollo-codegen-flow/lib/language';
@@ -71,12 +71,9 @@ export default function generate(
       writeOperationIdsMap(context);
       writtenFiles += 1;
     }
-  } else if (target === "flow" || target === "typescript" || target === "ts") {
+  } else if (target === "flow") {
     const context = compileToIR(schema, document, options);
-    const { generatedFiles, common } =
-      target === "flow"
-        ? generateFlowSource(context)
-        : generateTypescriptSource(context);
+    const { generatedFiles, common } = generateFlowSource(context);
 
     const outFiles: {
       [fileName: string]: BasicGeneratedFile;
@@ -116,6 +113,52 @@ export default function generate(
       fs.writeFileSync(
         outputPath,
         generatedFiles.map(o => o.content.fileContents).join("\n") + common
+      );
+
+      writtenFiles += 1;
+    }
+  } else if (target === "typescript" || target === "ts") {
+    const context = compileToIR(schema, document, options);
+    const generatedFiles = generateTypescriptLocalSource(context);
+    const generatedGlobalFile = generateTypescriptGlobalSource(context);
+
+    const outFiles: {
+      [fileName: string]: BasicGeneratedFile;
+    } = {};
+
+    if (nextToSources || (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory())) {
+      if (nextToSources && !fs.existsSync(outputPath)) {
+        fs.mkdirSync(outputPath);
+      }
+
+      const globalSourcePath = path.join(outputPath, "globalTypes.ts");
+      outFiles[globalSourcePath] = {
+        output: generatedGlobalFile.fileContents,
+      };
+
+      generatedFiles.forEach(({ sourcePath, fileName, content }) => {
+        let dir = outputPath;
+        if (nextToSources) {
+          dir = path.join(path.dirname(sourcePath), dir);
+          if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+          }
+        }
+
+        const outFilePath = path.join(dir, fileName);
+        outFiles[outFilePath] = {
+          output: content({ outputPath: outFilePath, globalSourcePath }).fileContents,
+        };
+      });
+
+      writeGeneratedFiles(outFiles, path.resolve("."));
+
+      writtenFiles += Object.keys(outFiles).length;
+    } else {
+      fs.writeFileSync(
+        outputPath,
+        generatedFiles.map(o => o.content().fileContents).join("\n") +
+          generatedGlobalFile.fileContents,
       );
 
       writtenFiles += 1;

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -646,6 +646,977 @@ export interface HeroNameVariables {
 }
 `;
 
+exports[`Typescript codeGeneration local / global fragment spreads with inline fragments 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero_Human_friends_Human {
+  __typename: \\"Human\\";
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+}
+
+export interface HeroName_hero_Human_friends_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * The ID of the droid
+   */
+  id: string;
+}
+
+export type HeroName_hero_Human_friends = HeroName_hero_Human_friends_Human | HeroName_hero_Human_friends_Droid;
+
+export interface HeroName_hero_Human {
+  __typename: \\"Human\\";
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+  /**
+   * The ID of the human
+   */
+  id: string;
+  /**
+   * The home planet of the human, or null if unknown
+   */
+  homePlanet: string | null;
+  /**
+   * This human's friends, or an empty list if they have none
+   */
+  friends: (HeroName_hero_Human_friends | null)[] | null;
+}
+
+export interface HeroName_hero_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * What others call this droid
+   */
+  name: string;
+  /**
+   * The ID of the droid
+   */
+  id: string;
+  /**
+   * The movies this droid appears in
+   */
+  appearsIn: (Episode | null)[];
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroName.ts",
+    "sourcePath": "GraphQL request",
+  },
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL fragment: humanFragment
+// ====================================================
+
+export interface humanFragment_friends_Human {
+  __typename: \\"Human\\";
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+}
+
+export interface humanFragment_friends_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * The ID of the droid
+   */
+  id: string;
+}
+
+export type humanFragment_friends = humanFragment_friends_Human | humanFragment_friends_Droid;
+
+export interface humanFragment {
+  __typename: \\"Human\\";
+  /**
+   * The home planet of the human, or null if unknown
+   */
+  homePlanet: string | null;
+  /**
+   * This human's friends, or an empty list if they have none
+   */
+  friends: (humanFragment_friends | null)[] | null;
+}",
+    },
+    "fileName": "humanFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL fragment: droidFragment
+// ====================================================
+
+export interface droidFragment {
+  __typename: \\"Droid\\";
+  /**
+   * The movies this droid appears in
+   */
+  appearsIn: (Episode | null)[];
+}",
+    },
+    "fileName": "droidFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global fragment spreads with inline fragments 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global fragment with fragment spreads 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: simpleFragment
+// ====================================================
+
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}",
+    },
+    "fileName": "simpleFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: anotherFragment
+// ====================================================
+
+export interface anotherFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The ID of the character
+   */
+  id: string;
+  /**
+   * The name of the character
+   */
+  name: string;
+}",
+    },
+    "fileName": "anotherFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global fragment with fragment spreads 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global fragment with fragment spreads with inline fragment 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL fragment: simpleFragment
+// ====================================================
+
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}",
+    },
+    "fileName": "simpleFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL fragment: anotherFragment
+// ====================================================
+
+export interface anotherFragment_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * The ID of the droid
+   */
+  id: string;
+  /**
+   * What others call this droid
+   */
+  name: string;
+}
+
+export interface anotherFragment_Human {
+  __typename: \\"Human\\";
+  /**
+   * The ID of the human
+   */
+  id: string;
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+  /**
+   * The movies this human appears in
+   */
+  appearsIn: (Episode | null)[];
+}
+
+export type anotherFragment = anotherFragment_Droid | anotherFragment_Human;",
+    },
+    "fileName": "anotherFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global fragment with fragment spreads with inline fragment 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global handles multiline graphql comments 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: CustomScalar
+// ====================================================
+
+export interface CustomScalar_commentTest {
+  __typename: \\"CommentTest\\";
+  /**
+   * This is a
+   * multi-line
+   * comment.
+   */
+  multiLine: string | null;
+}
+
+export interface CustomScalar {
+  commentTest: CustomScalar_commentTest | null;
+}",
+    },
+    "fileName": "CustomScalar.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global handles multiline graphql comments 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroInlineFragment
+// ====================================================
+
+export interface HeroInlineFragment_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroInlineFragment {
+  hero: HeroInlineFragment_hero | null;
+}
+
+export interface HeroInlineFragmentVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroInlineFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment on type conditions 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero_Human_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}
+
+export interface HeroName_hero_Human {
+  __typename: \\"Human\\";
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+  /**
+   * The ID of the human
+   */
+  id: string;
+  /**
+   * The home planet of the human, or null if unknown
+   */
+  homePlanet: string | null;
+  /**
+   * This human's friends, or an empty list if they have none
+   */
+  friends: (HeroName_hero_Human_friends | null)[] | null;
+}
+
+export interface HeroName_hero_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * What others call this droid
+   */
+  name: string;
+  /**
+   * The ID of the droid
+   */
+  id: string;
+  /**
+   * The movies this droid appears in
+   */
+  appearsIn: (Episode | null)[];
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroName.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment on type conditions 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment on type conditions with differing inner fields 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero_Human_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}
+
+export interface HeroName_hero_Human {
+  __typename: \\"Human\\";
+  /**
+   * What this human calls themselves
+   */
+  name: string;
+  /**
+   * The ID of the human
+   */
+  id: string;
+  /**
+   * The home planet of the human, or null if unknown
+   */
+  homePlanet: string | null;
+  /**
+   * This human's friends, or an empty list if they have none
+   */
+  friends: (HeroName_hero_Human_friends | null)[] | null;
+}
+
+export interface HeroName_hero_Droid_friends {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroName_hero_Droid {
+  __typename: \\"Droid\\";
+  /**
+   * What others call this droid
+   */
+  name: string;
+  /**
+   * The ID of the droid
+   */
+  id: string;
+  /**
+   * The movies this droid appears in
+   */
+  appearsIn: (Episode | null)[];
+  /**
+   * This droid's friends, or an empty list if they have none
+   */
+  friends: (HeroName_hero_Droid_friends | null)[] | null;
+}
+
+export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroName.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global inline fragment on type conditions with differing inner fields 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global query with fragment spreads 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroFragment
+// ====================================================
+
+export interface HeroFragment_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroFragment {
+  hero: HeroFragment_hero | null;
+}
+
+export interface HeroFragmentVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL fragment: simpleFragment
+// ====================================================
+
+export interface simpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}",
+    },
+    "fileName": "simpleFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global query with fragment spreads 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global simple fragment 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: SimpleFragment
+// ====================================================
+
+export interface SimpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+}",
+    },
+    "fileName": "SimpleFragment.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global simple fragment 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global simple hero query 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}",
+    },
+    "fileName": "HeroName.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global simple hero query 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
+exports[`Typescript codeGeneration local / global simple mutation 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { Episode, ReviewInput, ColorInput } from \\"../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL mutation operation: ReviewMovie
+// ====================================================
+
+export interface ReviewMovie_createReview {
+  __typename: \\"Review\\";
+  /**
+   * The number of stars this review gave, 1-5
+   */
+  stars: number;
+  /**
+   * Comment about the movie
+   */
+  commentary: string | null;
+}
+
+export interface ReviewMovie {
+  createReview: ReviewMovie_createReview | null;
+}
+
+export interface ReviewMovieVariables {
+  episode?: Episode | null;
+  review?: ReviewInput | null;
+}",
+    },
+    "fileName": "ReviewMovie.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global simple mutation 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+/**
+ * The input object sent when someone is creating a new review
+ */
+export interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
+
+/**
+ * The input object sent when passing in a color
+ */
+export interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================",
+}
+`;
+
 exports[`Typescript codeGeneration multiple files 1`] = `"generatedFiles"`;
 
 exports[`Typescript codeGeneration multiple files 2`] = `

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -735,8 +735,6 @@ export interface HeroNameVariables {
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { Episode } from \\"../../__generated__/globalTypes\\";
-
 // ====================================================
 // GraphQL fragment: humanFragment
 // ====================================================
@@ -905,8 +903,6 @@ Array [
 
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
-
-import { Episode } from \\"../../__generated__/globalTypes\\";
 
 // ====================================================
 // GraphQL fragment: simpleFragment
@@ -1374,8 +1370,6 @@ export interface HeroFragmentVariables {
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { Episode } from \\"../../__generated__/globalTypes\\";
-
 // ====================================================
 // GraphQL fragment: simpleFragment
 // ====================================================
@@ -1540,7 +1534,7 @@ Array [
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { Episode, ReviewInput, ColorInput } from \\"../../__generated__/globalTypes\\";
+import { Episode, ReviewInput } from \\"../../__generated__/globalTypes\\";
 
 // ====================================================
 // GraphQL mutation operation: ReviewMovie

--- a/packages/apollo-codegen-typescript/src/index.ts
+++ b/packages/apollo-codegen-typescript/src/index.ts
@@ -1,1 +1,1 @@
-export { generateSource } from './codeGeneration';
+export { generateSource, generateLocalSource, generateGlobalSource } from './codeGeneration';

--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLEnumType,
-  GraphQLInputObjectType
+  GraphQLInputObjectType,
+  GraphQLType
 } from 'graphql';
 
 import {
@@ -162,5 +163,15 @@ export default class TypescriptGenerator {
 
   public isNullableType(type: t.TSType) {
     return t.isTSUnionType(type) && type.types.some(type => t.isTSNullKeyword(type));
+  }
+
+  public import(types: GraphQLType[], source: string) {
+    return t.importDeclaration(
+      types.map((type) => t.importSpecifier(
+        t.identifier(type.toString()),
+        t.identifier(type.toString()),
+      )),
+      t.stringLiteral(source)
+    );
   }
 }


### PR DESCRIPTION
This change will deduplicate enum and input definitions by placing them in a global types file (`${outputPath}/globalTypes.ts`). Those global types will no longer be printed into the "local" type files, instead they will be imported.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->