### PR TITLE
Fall back to other methods of schema loading when one fails

### DIFF
--- a/packages/apollo-cli/src/load-schema.ts
+++ b/packages/apollo-cli/src/load-schema.ts
@@ -7,15 +7,28 @@ export async function loadSchema(
   config: ApolloConfig
 ): Promise<GraphQLSchema | undefined> {
   if (dependency.schema) {
-    return await fetchSchema({ url: dependency.schema }, config.projectFolder);
-  } else if (dependency.endpoint && dependency.endpoint.url) {
-    return await fetchSchema(dependency.endpoint, config.projectFolder);
-  } else if (dependency.engineKey) {
-    return await fetchSchemaFromEngine(
-      dependency.engineKey,
-      config.engineEndpoint
-    );
-  } else {
-    return undefined;
+    try {
+      return await fetchSchema(
+        { url: dependency.schema },
+        config.projectFolder
+      );
+    } catch {}
   }
+
+  if (dependency.endpoint && dependency.endpoint.url) {
+    try {
+      return await fetchSchema(dependency.endpoint, config.projectFolder);
+    } catch {}
+  }
+
+  if (dependency.engineKey) {
+    try {
+      return await fetchSchemaFromEngine(
+        dependency.engineKey,
+        config.engineEndpoint
+      );
+    } catch {}
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Helps in situations where one method fails like when an endpoint exists but introspection is disabled.