### PR TITLE
Allow to run `apollo codegen:generate --watch` on non tty devices

### DIFF
--- a/packages/apollo-cli/src/commands/codegen/generate.ts
+++ b/packages/apollo-cli/src/commands/codegen/generate.ts
@@ -2,6 +2,7 @@ import "apollo-codegen-core/lib/polyfills";
 import { Command, flags } from "@oclif/command";
 import * as Listr from "listr";
 import * as path from "path";
+import * as tty from "tty";
 
 import { TargetType, default as generate } from "../../generate";
 
@@ -245,8 +246,10 @@ export default class Generate extends Command {
         console.log("\nChange detected, generating types...");
         tasks.run().catch(() => {});
       });
-      await waitForKey();
-      watcher.close();
+      if (tty.isatty((process.stdin as any).fd)) {
+        await waitForKey();
+        watcher.close();
+      }
       return;
     } else {
       return tasks.run();


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Currently it's not possible to use the `--watch` options if the stdin is not a tty (e. g. if the command is run using the [concurrently](https://www.npmjs.com/package/concurrently) cli tool). You can reproduce this bug with the following command:

```bash
apollo codegen:generate --target=typescript --schema=src/data/schema.json '--queries=src/**/*.tsx' --watch < /dev/null
```

You'll see the following output:

```
 ✔ Loading Apollo config
 ✔ Scanning for GraphQL queries (6 found)
 ✔ Generating query files with 'typescript' target - wrote 3 files
Press any key to stop.
TypeError: process.stdin.setRawMode is not a function
    at waitForKey (~/Projects/omnicalc/node_modules/apollo/lib/commands/codegen/generate.js:17:19)
    at Generate.run (~/Projects/omnicalc/node_modules/apollo/lib/commands/codegen/generate.js:127:23)
    at <anonymous>
```

This PR fixes the problem.