### PR TITLE
Support for self-signed certificates

### DIFF
--- a/packages/apollo-cli/src/commands/schema/download.ts
+++ b/packages/apollo-cli/src/commands/schema/download.ts
@@ -35,7 +35,7 @@ export default class SchemaDownload extends Command {
       description:
         "The URL of the server to fetch the schema from or path to ./your/local/schema.graphql"
     }),
-    insecure: flags.boolean({
+    skipSSLValidation: flags.boolean({
       char: "k",
       description: "Allow connections to a SSL site without certs"
     }),

--- a/packages/apollo-cli/src/commands/schema/download.ts
+++ b/packages/apollo-cli/src/commands/schema/download.ts
@@ -35,6 +35,10 @@ export default class SchemaDownload extends Command {
       description:
         "The URL of the server to fetch the schema from or path to ./your/local/schema.graphql"
     }),
+    insecure: flags.boolean({
+      char: "k",
+      description: "Allow connections to a SSL site without certs"
+    }),
 
     ...engineFlags
   };

--- a/packages/apollo-cli/src/config.ts
+++ b/packages/apollo-cli/src/config.ts
@@ -11,6 +11,7 @@ export interface EndpointConfig {
   url?: string; // main HTTP endpoint
   subscriptions?: string; // WS endpoint for subscriptions
   headers?: Object; // headers to send when performing operations
+  skipSSLValidation?: boolean; // bypass the SSL validation on a HTTPS request
 }
 
 export interface SchemaDependency {
@@ -19,7 +20,6 @@ export interface SchemaDependency {
   engineKey?: string;
   extends?: string;
   clientSide?: boolean;
-  skipsSSLValidation?: boolean;
 }
 
 export interface DocumentSet {

--- a/packages/apollo-cli/src/config.ts
+++ b/packages/apollo-cli/src/config.ts
@@ -19,6 +19,7 @@ export interface SchemaDependency {
   engineKey?: string;
   extends?: string;
   clientSide?: boolean;
+  skipsSSLValidation?: boolean;
 }
 
 export interface DocumentSet {

--- a/packages/apollo-cli/src/fetch-schema.ts
+++ b/packages/apollo-cli/src/fetch-schema.ts
@@ -50,24 +50,23 @@ export async function fromFile(
 }
 
 export const fetchSchema = async (
-  { url, headers }: EndpointConfig,
-  projectFolder?: string,
-  insecureEnabled?: boolean
+  { url, headers, skipSSLValidation }: EndpointConfig,
+  projectFolder?: string
 ): Promise<GraphQLSchema | undefined> => {
   if (!url) throw new Error("No endpoint provided when fetching schema");
   const filePath = projectFolder ? path.resolve(projectFolder, url) : url;
   if (fs.existsSync(filePath)) return fromFile(filePath);
 
-  const insecureOptionActive = insecureEnabled ? insecureEnabled : false;
-
   var options: HttpLink.Options = { uri: url, fetch }
 
-  if (insecureOptionActive) {
-    const host = new URL(url).host
+  if (skipSSLValidation) {
+    const urlObject = new URL(url)
+    const host = urlObject.host
+    const port = +urlObject.port || 443
 
     const agentOptions: AgentOptions = {
       host: host,
-      port: 443,
+      port: port,
       rejectUnauthorized: false
     };
 

--- a/packages/apollo-cli/src/fetch-schema.ts
+++ b/packages/apollo-cli/src/fetch-schema.ts
@@ -1,20 +1,15 @@
-import { fs } from "apollo-codegen-core/lib/localfs";
-import * as path from "path";
-import fetch from "node-fetch";
-import gql from "graphql-tag";
-import {
-  buildSchema,
-  introspectionQuery,
-  GraphQLSchema,
-  Source,
-  buildClientSchema
-} from "graphql";
-import { execute, toPromise } from "apollo-link";
-import { createHttpLink } from "apollo-link-http";
-
 import { extractDocumentFromJavascript } from "apollo-codegen-core/lib/loading";
+import { fs } from "apollo-codegen-core/lib/localfs";
+import { execute, toPromise } from "apollo-link";
+import { createHttpLink, HttpLink } from "apollo-link-http";
+import { buildClientSchema, buildSchema, GraphQLSchema, introspectionQuery, Source } from "graphql";
+import gql from "graphql-tag";
+import { Agent, AgentOptions } from 'https';
+import fetch from "node-fetch";
+import * as path from "path";
+import { URL } from 'url';
 import { EndpointConfig } from "./config";
-import { getIdFromKey, engineLink } from "./engine";
+import { engineLink, getIdFromKey } from "./engine";
 import { SCHEMA_QUERY } from "./operations/schema";
 
 const introspection = gql(introspectionQuery);
@@ -56,15 +51,35 @@ export async function fromFile(
 
 export const fetchSchema = async (
   { url, headers }: EndpointConfig,
-  projectFolder?: string
+  projectFolder?: string,
+  insecureEnabled?: boolean
 ): Promise<GraphQLSchema | undefined> => {
   if (!url) throw new Error("No endpoint provided when fetching schema");
   const filePath = projectFolder ? path.resolve(projectFolder, url) : url;
   if (fs.existsSync(filePath)) return fromFile(filePath);
 
+  const insecureOptionActive = insecureEnabled ? insecureEnabled : false;
+
+  var options: HttpLink.Options = { uri: url, fetch }
+
+  if (insecureOptionActive) {
+    const host = new URL(url).host
+
+    const agentOptions: AgentOptions = {
+      host: host,
+      port: 443,
+      rejectUnauthorized: false
+    };
+
+    const agent = new Agent(agentOptions);
+
+    options.fetchOptions = { agent: agent }
+  }
+
   return toPromise(
-    // XXX node-fetch isn't compatiable typescript wise here?
-    execute(createHttpLink({ uri: url, fetch } as any), {
+
+    // XXX node-fetch isn't compatible typescript wise here?
+    execute(createHttpLink(options), {
       query: introspection,
       context: { headers }
     })

--- a/packages/apollo-cli/src/load-config.ts
+++ b/packages/apollo-cli/src/load-config.ts
@@ -1,9 +1,5 @@
-import {
-  loadConfigFromFile,
-  findAndLoadConfig,
-  SchemaDependency
-} from "./config";
 import { ListrTask } from "listr";
+import { findAndLoadConfig, loadConfigFromFile, SchemaDependency } from "./config";
 
 export function loadConfigStep(
   flags: any,
@@ -87,9 +83,12 @@ export function loadConfigStep(
         ctx.config.engineEndpoint = flags.engine;
       }
 
-      if (flags.insecure) {
+      if (flags.skipSSLValidation) {
         if (Object.keys(ctx.config.schemas).length == 1) {
-          (Object.values(ctx.config.schemas)[0] as SchemaDependency).skipsSSLValidation = flags.insecure;
+          const endpointConfiguration = (Object.values(ctx.config.schemas)[0] as SchemaDependency).endpoint
+          if (endpointConfiguration) {
+            endpointConfiguration.skipSSLValidation = flags.skipSSLValidation
+          }
         }
       }
 

--- a/packages/apollo-cli/src/load-config.ts
+++ b/packages/apollo-cli/src/load-config.ts
@@ -87,6 +87,12 @@ export function loadConfigStep(
         ctx.config.engineEndpoint = flags.engine;
       }
 
+      if (flags.insecure) {
+        if (Object.keys(ctx.config.schemas).length == 1) {
+          (Object.values(ctx.config.schemas)[0] as SchemaDependency).skipsSSLValidation = flags.insecure;
+        }
+      }
+
       if (ctx.config.queries.length == 0 && ctx.config.schemas.default) {
         ctx.config.queries.push({
           schema: "default",

--- a/packages/apollo-cli/src/load-schema.ts
+++ b/packages/apollo-cli/src/load-schema.ts
@@ -1,6 +1,6 @@
-import { SchemaDependency, ApolloConfig } from "./config";
-import { fetchSchema, fetchSchemaFromEngine } from "./fetch-schema";
 import { GraphQLSchema } from "graphql";
+import { ApolloConfig, SchemaDependency } from "./config";
+import { fetchSchema, fetchSchemaFromEngine } from "./fetch-schema";
 
 export async function loadSchema(
   dependency: SchemaDependency,
@@ -17,7 +17,7 @@ export async function loadSchema(
 
   if (dependency.endpoint && dependency.endpoint.url) {
     try {
-      return await fetchSchema(dependency.endpoint, config.projectFolder, dependency.skipsSSLValidation);
+      return await fetchSchema(dependency.endpoint, config.projectFolder);
     } catch {}
   }
 

--- a/packages/apollo-cli/src/load-schema.ts
+++ b/packages/apollo-cli/src/load-schema.ts
@@ -17,7 +17,7 @@ export async function loadSchema(
 
   if (dependency.endpoint && dependency.endpoint.url) {
     try {
-      return await fetchSchema(dependency.endpoint, config.projectFolder);
+      return await fetchSchema(dependency.endpoint, config.projectFolder, dependency.skipsSSLValidation);
     } catch {}
   }
 


### PR DESCRIPTION
### Adds support for skipping certificate validation

Often developers use a self-signed certificate for local services. In development process is not uncommon to see those kind of https requests without a Root CA signed certificate. This PR tries to solve the issue reported on #199 when using `apollo-cli` for downloading the GraphQL schema.

`schema:download` has a new option `--insecure` or equally `-k`  for skipping certificate validation. These names were chosen following the popular unix command `curl` convention.

It is my first PR on the project so any kind of feedback is more than welcome.

Fixes #199 