### PR TITLE
Fix the VSCode extension build setup

### DIFF
--- a/packages/apollo-language-server/copy-apollo-libs.sh
+++ b/packages/apollo-language-server/copy-apollo-libs.sh
@@ -5,10 +5,10 @@
 # to NPM. So we copy all the local lib folders into the installed NPM packages to get them up to date
 # with what we have in the Lerna build.
 
-cp -r ../apollo/lib ../apollo-vscode/server/node_modules/apollo
-cp -r ../apollo-codegen-core/lib ../apollo-vscode/server/node_modules/apollo-codegen-core
-cp -r ../apollo-codegen-flow-legacy/lib ../apollo-vscode/server/node_modules/apollo-codegen-flow-legacy
-cp -r ../apollo-codegen-scala/lib ../apollo-vscode/server/node_modules/apollo-codegen-scala
-cp -r ../apollo-codegen-swift/lib ../apollo-vscode/server/node_modules/apollo-codegen-swift
-cp -r ../apollo-codegen-typescript/lib ../apollo-vscode/server/node_modules/apollo-codegen-typescript
-cp -r ../apollo-codegen-typescript-legacy/lib ../apollo-vscode/server/node_modules/apollo-codegen-typescript-legacy
+cp -r ../apollo ../apollo-vscode/server/node_modules/apollo
+cp -r ../apollo-codegen-core ../apollo-vscode/server/node_modules/apollo-codegen-core
+cp -r ../apollo-codegen-flow-legacy ../apollo-vscode/server/node_modules/apollo-codegen-flow-legacy
+cp -r ../apollo-codegen-scala ../apollo-vscode/server/node_modules/apollo-codegen-scala
+cp -r ../apollo-codegen-swift ../apollo-vscode/server/node_modules/apollo-codegen-swift
+cp -r ../apollo-codegen-typescript ../apollo-vscode/server/node_modules/apollo-codegen-typescript
+cp -r ../apollo-codegen-typescript-legacy ../apollo-vscode/server/node_modules/apollo-codegen-typescript-legacy

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -1,6 +1,3 @@
-// Seems to be needed for graphql-language-service-server
-import "regenerator-runtime/runtime";
-
 import {
   createConnection,
   ProposedFeatures,

--- a/packages/apollo-vscode-webview/webpack.config.js
+++ b/packages/apollo-vscode-webview/webpack.config.js
@@ -45,7 +45,12 @@ module.exports = {
     strictExportPresence: true,
     rules: [
       {
-        test: /\.(js|jsx|mjs)$/,
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: "javascript/auto"
+      },
+      {
+        test: /\.(js|jsx)$/,
         include: path.resolve("src"),
         loader: require.resolve("babel-loader"),
         options: {
@@ -67,15 +72,15 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: 'style-loader!css-loader',
+        loader: "style-loader!css-loader"
       },
       {
         test: /\.svg$/,
-        loader: 'url-loader'
+        loader: "url-loader"
       },
       {
         test: /\.png$/,
-        loader: 'url-loader'
+        loader: "url-loader"
       }
     ]
   },
@@ -88,7 +93,7 @@ module.exports = {
     // It is absolutely essential that NODE_ENV was set to production here.
     // Otherwise React will be compiled in the very slow development mode.
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production')
+      "process.env.NODE_ENV": JSON.stringify("production")
     }),
     // Minify the code.
     new UglifyJsPlugin({

--- a/packages/apollo-vscode-webview/webpack.config.js
+++ b/packages/apollo-vscode-webview/webpack.config.js
@@ -8,6 +8,7 @@ const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
 module.exports = {
+  mode: "production",
   // Don't attempt to continue if there are any errors.
   bail: true,
   devtool: false,


### PR DESCRIPTION
Two main fixes:
1. Copy the entire monorepo package folders into the server `node_modules` so that `*/lib/*` resolves to the files there.
2. Add an extra rule to handle `.mjs` files to prevent Webpack issues with `graphql-js`

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->