### PR TITLE
Issue #215 - Make Swift Enums conform to Hashable

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1467,7 +1467,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
-"public enum AlbumPrivacies: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+"public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   case \`public\`
   case \`private\`
@@ -1544,7 +1544,7 @@ public struct ReviewInput: GraphQLMapConvertible {
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
-public enum Episode: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum Episode: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   /// Star Wars Episode IV: A New Hope, released in 1977.
   case newhope

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -890,7 +890,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     this.printNewlineIfNeeded();
     this.comment(description || undefined);
     this.printOnNewline(
-      `public enum ${name}: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable`
+      `public enum ${name}: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable`
     );
     this.withinBlock(() => {
       this.printOnNewline("public typealias RawValue = String");


### PR DESCRIPTION
# What

Makes `enum`s conform to `Hashable`. The actual conformance is automatically synthesized by the Swift 4.1 compiler.

# Why

In response to https://github.com/apollographql/apollo-cli/issues/215

# Testing

In my local environment I was able to verify simply adding `Hashable` worked as expected, and it could be used in external code as if it was `Hashable`. As long as CI's tests pass, this should be good to go.

# Problems

Swift 4.1 only exists in Xcode 9.3, and not 9.2 or below. From what I can see, Apollo still supports "Xcode 9 and Swift 4", so that will no longer be completely true. However, Swift 4.1 is a non-source-breaking change, and having `enum`s automatically implement `Hashable` is a nice win.

- [x] feature
- [ ] blocking
- [ ] docs