### PR TITLE
Migrate stats query to druid, update how the data is consumed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "postinstall": "lerna run prepare",
     "build": "lerna run build",
+    "watch": "lerna run watch --stream --no-sort --concurrency 20",
     "lint": "prettier --list-different \"packages/*/src/**/*.{js,jsx,ts,tsx}\"",
     "lint-fix": "prettier --write \"packages/*/src/**/*.{js,jsx,ts,tsx}\"",
     "test": "jest --verbose",

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -236,13 +236,9 @@ export class GraphQLProject {
 
             this.engineStats.set(schemaDef.engineKey, schemaEngineStats);
           }
-
-          return;
         })
       )
     );
-
-    return;
   }
 
   async scanAllIncludedFiles() {

--- a/packages/apollo-vscode/package.json
+++ b/packages/apollo-vscode/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf lib",
     "prebuild": "npm run clean",
     "build": "tsc",
+    "watch": "tsc -w -p .",
     "prepare": "npm run build",
     "postinstall": "npm run update-vscode",
     "update-vscode": "node ../../node_modules/vscode/bin/install",


### PR DESCRIPTION
This PR cuts the stats query over to Druid. Also add watch support for better extension development.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->