### PR TITLE
Restructure `apollo queries:extract` logic and manifest format.

### DIFF
--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -59,7 +59,7 @@ export default class ExtractQueries extends Command {
         task: (ctx, task) => {
           const filename = args.output;
           task.title = "Outputing extracted queries to " + filename;
-          writeFileSync(filename, JSON.stringify(ctx.mapping));
+          writeFileSync(filename, JSON.stringify(ctx.manifest));
         }
       }
     ]);

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -3,7 +3,7 @@ import "apollo-codegen-core/lib/polyfills";
 
 import { Command, flags } from "@oclif/command";
 import * as Listr from "listr";
-import * as fs from "fs";
+import { writeFileSync } from "fs";
 
 import {
   getCommonTasks,
@@ -59,7 +59,7 @@ export default class ExtractQueries extends Command {
         task: async (ctx, task) => {
           const filename = args.output;
           task.title = "Outputing extracted queries to " + filename;
-          fs.writeFileSync(filename, JSON.stringify(ctx.mapping));
+          writeFileSync(filename, JSON.stringify(ctx.mapping));
         }
       }
     ]);

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -56,7 +56,7 @@ export default class ExtractQueries extends Command {
       ...getCommonManifestTasks(),
       {
         title: "Outputing extracted queries",
-        task: async (ctx, task) => {
+        task: (ctx, task) => {
           const filename = args.output;
           task.title = "Outputing extracted queries to " + filename;
           writeFileSync(filename, JSON.stringify(ctx.mapping));

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -59,7 +59,7 @@ export default class ExtractQueries extends Command {
         task: (ctx, task) => {
           const filename = args.output;
           task.title = "Outputing extracted queries to " + filename;
-          writeFileSync(filename, JSON.stringify(ctx.manifest));
+          writeFileSync(filename, JSON.stringify(ctx.manifest, null, 2));
         }
       }
     ]);

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -3,16 +3,12 @@ import "apollo-codegen-core/lib/polyfills";
 
 import { Command, flags } from "@oclif/command";
 import * as Listr from "listr";
-import * as crypto from "crypto";
 import * as fs from "fs";
-import { DocumentNode } from "graphql";
-import {
-  hideLiterals,
-  printWithReducedWhitespace,
-  sortAST
-} from "apollo-engine-reporting";
 
-import { getCommonTasks } from "../../helpers/commands/queries/commonTasks";
+import {
+  getCommonTasks,
+  getCommonManifestTasks
+} from "../../helpers/commands/queries/commonTasks";
 
 import { engineFlags } from "../../engine-cli";
 
@@ -57,34 +53,7 @@ export default class ExtractQueries extends Command {
     const tasks: Listr = new Listr([
       loadConfigStep(flags, false),
       ...getCommonTasks({ flags, errorLogger: this.error.bind(this) }),
-      {
-        title: "Normalizing Operations",
-        task: async ctx => {
-          ctx.normalizedOperations = (ctx.fullOperations as Array<
-            DocumentNode
-          >).map(operation =>
-            // While this could include dropping unused definitions, they are
-            // kept because the registered operations should mirror those in the
-            // client bundle minus any PPI. This provides more predictability
-            // and allows a better understanding of where a query comes from.
-            printWithReducedWhitespace(sortAST(hideLiterals(operation)))
-          );
-        }
-      },
-      {
-        title: "Generating hashes",
-        task: async ctx => {
-          ctx.mapping = {};
-          (ctx.normalizedOperations as Array<string>).forEach(operation => {
-            ctx.mapping[
-              crypto
-                .createHash("sha512")
-                .update(operation)
-                .digest("base64")
-            ] = operation;
-          });
-        }
-      },
+      ...getCommonManifestTasks(),
       {
         title: "Outputing extracted queries",
         task: async (ctx, task) => {

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -12,14 +12,10 @@ import {
   sortAST
 } from "apollo-engine-reporting";
 
-import {
-  loadQueryDocuments,
-  extractOperationsAndFragments,
-  combineOperationsAndFragments
-} from "apollo-codegen-core/lib/loading";
+import { getCommonTasks } from "../../helpers/commands/queries/commonTasks";
 
 import { engineFlags } from "../../engine-cli";
-import { resolveDocumentSets } from "../../config";
+
 import { loadConfigStep } from "../../load-config";
 
 export default class ExtractQueries extends Command {
@@ -60,45 +56,7 @@ export default class ExtractQueries extends Command {
 
     const tasks: Listr = new Listr([
       loadConfigStep(flags, false),
-      {
-        title: "Resolving GraphQL document sets",
-        task: async ctx => {
-          ctx.documentSets = await resolveDocumentSets(ctx.config, false);
-        }
-      },
-      {
-        title: "Scanning for GraphQL queries",
-        task: async (ctx, task) => {
-          ctx.queryDocuments = loadQueryDocuments(
-            ctx.documentSets[0].documentPaths,
-            flags.tagName
-          );
-          task.title = `Scanning for GraphQL queries (${
-            ctx.queryDocuments.length
-          } found)`;
-        }
-      },
-      {
-        title: "Isolating operations and fragments",
-        task: async ctx => {
-          const { fragments, operations } = extractOperationsAndFragments(
-            ctx.queryDocuments,
-            this.error.bind(this)
-          );
-          ctx.fragments = fragments;
-          ctx.operations = operations;
-        }
-      },
-      {
-        title: "Combining operations and fragments",
-        task: async ctx => {
-          ctx.fullOperations = combineOperationsAndFragments(
-            ctx.operations,
-            ctx.fragments,
-            this.error.bind(this)
-          );
-        }
-      },
+      ...getCommonTasks({ flags, errorLogger: this.error.bind(this) }),
       {
         title: "Normalizing Operations",
         task: async ctx => {

--- a/packages/apollo/src/helpers/commands/queries/commonTasks.ts
+++ b/packages/apollo/src/helpers/commands/queries/commonTasks.ts
@@ -32,7 +32,7 @@ const taskResolveDocumentSets = (): ListrTask => ({
 
 const taskScanForOperations = ({ flags }: { flags: any }): ListrTask => ({
   title: "Scanning for GraphQL queries",
-  task: async (ctx, task) => {
+  task: (ctx, task) => {
     // Make sure the expectations of our context are correct.
     assert.strictEqual(typeof ctx.queryDocuments, "undefined");
 
@@ -52,7 +52,7 @@ const taskIsolateOperationsAndFragments = ({
   errorLogger?: ErrorLogger;
 }): ListrTask => ({
   title: "Isolating operations and fragments",
-  task: async ctx => {
+  task: ctx => {
     // Make sure the expectations of our context are correct.
     assert.strictEqual(typeof ctx.fragments, "undefined");
     assert.strictEqual(typeof ctx.operations, "undefined");
@@ -72,7 +72,7 @@ const taskCombineOperationsAndFragments = ({
   errorLogger?: ErrorLogger;
 }): ListrTask => ({
   title: "Combining operations and fragments",
-  task: async ctx => {
+  task: ctx => {
     // Make sure the expectations of our context are correct.
     assert.strictEqual(typeof ctx.fullOperations, "undefined");
 

--- a/packages/apollo/src/helpers/commands/queries/commonTasks.ts
+++ b/packages/apollo/src/helpers/commands/queries/commonTasks.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 import { ListrTask } from "listr";
+import * as assert from "assert";
 
 import {
   loadQueryDocuments,
@@ -21,6 +22,10 @@ type ErrorLogger = (message: string) => void;
 const taskResolveDocumentSets = (): ListrTask => ({
   title: "Resolving GraphQL document sets",
   task: async ctx => {
+    // Make sure the expectations of our context are correct.
+    assert.notStrictEqual(typeof ctx.config, "undefined");
+    assert.strictEqual(typeof ctx.documentSets, "undefined");
+
     ctx.documentSets = await resolveDocumentSets(ctx.config, false);
   }
 });
@@ -28,6 +33,9 @@ const taskResolveDocumentSets = (): ListrTask => ({
 const taskScanForOperations = ({ flags }: { flags: any }): ListrTask => ({
   title: "Scanning for GraphQL queries",
   task: async (ctx, task) => {
+    // Make sure the expectations of our context are correct.
+    assert.strictEqual(typeof ctx.queryDocuments, "undefined");
+
     ctx.queryDocuments = loadQueryDocuments(
       ctx.documentSets[0].documentPaths,
       flags.tagName
@@ -45,6 +53,10 @@ const taskIsolateOperationsAndFragments = ({
 }): ListrTask => ({
   title: "Isolating operations and fragments",
   task: async ctx => {
+    // Make sure the expectations of our context are correct.
+    assert.strictEqual(typeof ctx.fragments, "undefined");
+    assert.strictEqual(typeof ctx.operations, "undefined");
+
     const { fragments, operations } = extractOperationsAndFragments(
       ctx.queryDocuments,
       errorLogger
@@ -61,6 +73,9 @@ const taskCombineOperationsAndFragments = ({
 }): ListrTask => ({
   title: "Combining operations and fragments",
   task: async ctx => {
+    // Make sure the expectations of our context are correct.
+    assert.strictEqual(typeof ctx.fullOperations, "undefined");
+
     ctx.fullOperations = combineOperationsAndFragments(
       ctx.operations,
       ctx.fragments,

--- a/packages/apollo/src/helpers/commands/queries/commonTasks.ts
+++ b/packages/apollo/src/helpers/commands/queries/commonTasks.ts
@@ -105,9 +105,9 @@ export function getCommonTasks({
 */
 
 const manifestOperationHash = (str: string): string =>
-  createHash("sha512")
+  createHash("sha256")
     .update(str)
-    .digest("base64");
+    .digest("hex");
 
 const engineSignature = (_TODO_operationAST: DocumentNode): string => {
   // TODO.  We don't currently have access to the operation name since it's

--- a/packages/apollo/src/helpers/commands/queries/commonTasks.ts
+++ b/packages/apollo/src/helpers/commands/queries/commonTasks.ts
@@ -1,0 +1,77 @@
+import { ListrTask } from "listr";
+
+import {
+  loadQueryDocuments,
+  extractOperationsAndFragments,
+  combineOperationsAndFragments
+} from "apollo-codegen-core/lib/loading";
+
+import { resolveDocumentSets } from "../../../config";
+
+type ErrorLogger = (message: string) => void;
+
+const taskResolveDocumentSets = (): ListrTask => ({
+  title: "Resolving GraphQL document sets",
+  task: async ctx => {
+    ctx.documentSets = await resolveDocumentSets(ctx.config, false);
+  }
+});
+
+const taskScanForOperations = ({ flags }: { flags: any }): ListrTask => ({
+  title: "Scanning for GraphQL queries",
+  task: async (ctx, task) => {
+    ctx.queryDocuments = loadQueryDocuments(
+      ctx.documentSets[0].documentPaths,
+      flags.tagName
+    );
+    task.title = `Scanning for GraphQL queries (${
+      ctx.queryDocuments.length
+    } found)`;
+  }
+});
+
+const taskIsolateOperationsAndFragments = ({
+  errorLogger
+}: {
+  errorLogger?: ErrorLogger;
+}): ListrTask => ({
+  title: "Isolating operations and fragments",
+  task: async ctx => {
+    const { fragments, operations } = extractOperationsAndFragments(
+      ctx.queryDocuments,
+      errorLogger
+    );
+    ctx.fragments = fragments;
+    ctx.operations = operations;
+  }
+});
+
+const taskCombineOperationsAndFragments = ({
+  errorLogger
+}: {
+  errorLogger?: ErrorLogger;
+}): ListrTask => ({
+  title: "Combining operations and fragments",
+  task: async ctx => {
+    ctx.fullOperations = combineOperationsAndFragments(
+      ctx.operations,
+      ctx.fragments,
+      errorLogger
+    );
+  }
+});
+
+export function getCommonTasks({
+  flags,
+  errorLogger
+}: {
+  flags: any;
+  errorLogger?: ErrorLogger;
+}): ListrTask[] {
+  return [
+    taskResolveDocumentSets(),
+    taskScanForOperations({ flags }),
+    taskIsolateOperationsAndFragments({ errorLogger }),
+    taskCombineOperationsAndFragments({ errorLogger })
+  ];
+}


### PR DESCRIPTION
**Breaking changes:** This changes the output format of the manifest generated by `queries:extract` to be in a more evolvable format.  Existing users of the manifest produced by `manifest.json` should take care to observe the new manifest format, as indicated by the top-level presence of a `version` attribute (now `1`, previously `undefined`).

In general, this just moves some bits of often repeated portions of the CLI into a unified location where they can be shared by more modules as we use more and more portions in multiple places.