### PR TITLE
Revert "Fall back to other methods of schema loading... (#533)

### DIFF
--- a/packages/apollo/src/load-schema.ts
+++ b/packages/apollo/src/load-schema.ts
@@ -7,28 +7,15 @@ export async function loadSchema(
   config: ApolloConfig
 ): Promise<GraphQLSchema | undefined> {
   if (dependency.schema) {
-    try {
-      return await fetchSchema(
-        { url: dependency.schema },
-        config.projectFolder
-      );
-    } catch {}
+    return await fetchSchema({ url: dependency.schema }, config.projectFolder);
+  } else if (dependency.endpoint && dependency.endpoint.url) {
+    return await fetchSchema(dependency.endpoint, config.projectFolder);
+  } else if (dependency.engineKey) {
+    return await fetchSchemaFromEngine(
+      dependency.engineKey,
+      config.engineEndpoint
+    );
+  } else {
+    return undefined;
   }
-
-  if (dependency.endpoint && dependency.endpoint.url) {
-    try {
-      return await fetchSchema(dependency.endpoint, config.projectFolder);
-    } catch {}
-  }
-
-  if (dependency.engineKey) {
-    try {
-      return await fetchSchemaFromEngine(
-        dependency.engineKey,
-        config.engineEndpoint
-      );
-    } catch {}
-  }
-
-  return undefined;
 }


### PR DESCRIPTION
This reverts commit b48e7bf31ebb9f5cb8f4daa7830a8fb8c4c81d45.

As corroborated by the trending number of 👍 emotes on #560, this PR introduced a number of `try` `catch`es which silenced relatively useful information from their _tried_ operations.  I'm happy to help figure out a better approach but since this seems to have caused many more problems than it solved, we should consider a different approach.

cc @shadaj 

Closes #560