### PR TITLE
Avoid re-introspecting within local `graphql` context and exclude client-only directives.

### DIFF
--- a/packages/apollo-codegen-core/src/utilities/__tests__/graphql.test.ts
+++ b/packages/apollo-codegen-core/src/utilities/__tests__/graphql.test.ts
@@ -1,0 +1,100 @@
+import { parse, print } from "graphql";
+import {
+  withTypenameFieldAddedWhereNeeded,
+  removeConnectionDirectives,
+  removeClientDirectives
+} from "../graphql";
+
+describe("typename additions", () => {
+  it("adds typenames to selectionSets", () => {
+    const original = parse(`
+      query GetUser {
+          me {
+          firstName
+          friends {
+            firstName
+          }
+        }
+      }
+    `);
+
+    const modified = print(
+      parse(`
+      query GetUser {
+        me {
+          __typename
+          firstName
+          friends {
+            __typename
+            firstName
+          }
+        }
+      }
+    `)
+    );
+
+    const newQuery = withTypenameFieldAddedWhereNeeded(original);
+    expect(print(newQuery)).toEqual(modified);
+  });
+});
+
+describe("client removals", () => {
+  it("removes the @connection directive", () => {
+    const original = parse(`
+      query GetUser {
+        list @connection(key: "Value")
+      }
+    `);
+
+    const modified = print(
+      parse(`
+      query GetUser {
+        list
+      }
+    `)
+    );
+
+    const newQuery = removeConnectionDirectives(original);
+    expect(print(newQuery)).toEqual(modified);
+  });
+  it("removes @client id from a mixed query", () => {
+    const original = parse(`
+      query GetUser {
+        list @client
+        remote {
+          id
+          virtual @client
+          virtualSelectionSet @client @export(as: "id") {
+            name
+          }
+        }
+      }
+    `);
+
+    const modified = print(
+      parse(`
+      query GetUser {
+        remote {
+          id
+        }
+      }
+    `)
+    );
+
+    const newQuery = removeClientDirectives(original);
+    expect(print(newQuery)).toEqual(modified);
+  });
+  it("returns and empty string when removing all fields", () => {
+    const original = parse(`
+      query GetUser {
+        list @client
+        local @client {
+          id
+        }
+      }
+    `);
+
+    const newQuery = removeClientDirectives(original);
+    expect(print(newQuery).trim()).toBeFalsy();
+  });
+});

--- a/packages/apollo/src/commands/queries/extract.ts
+++ b/packages/apollo/src/commands/queries/extract.ts
@@ -29,6 +29,15 @@ export default class ExtractQueries extends Command {
       description:
         "Path to your GraphQL queries, can include search tokens like **"
     }),
+    addTypename: flags.boolean({
+      description: "Automatically add __typename to your queries",
+      allowNo: true
+    }),
+    removeClientDirectives: flags.boolean({
+      allowNo: true,
+      description:
+        "Automatically remove @client and @connection directives and fields from operations"
+    }),
     ...engineFlags,
 
     tagName: flags.string({
@@ -48,12 +57,16 @@ export default class ExtractQueries extends Command {
   ];
 
   async run() {
-    const { flags, args } = this.parse(ExtractQueries);
+    let { flags, args } = this.parse(ExtractQueries);
+
+    // oclif doesn't let setting boolean flags to be default
+    const defaultFlags = { addTypename: true, removeClientDirectives: true };
+    flags = { ...defaultFlags, ...flags };
 
     const tasks: Listr = new Listr([
       loadConfigStep(flags, false),
       ...getCommonTasks({ flags, errorLogger: this.error.bind(this) }),
-      ...getCommonManifestTasks(),
+      ...getCommonManifestTasks({ flags }),
       {
         title: "Outputing extracted queries",
         task: (ctx, task) => {

--- a/packages/apollo/src/commands/schema/check.ts
+++ b/packages/apollo/src/commands/schema/check.ts
@@ -2,13 +2,7 @@ import { Command, flags } from "@oclif/command";
 import chalk from "chalk";
 import { table, styledJSON } from "heroku-cli-util";
 import * as Listr from "listr";
-import {
-  GraphQLError,
-  parse,
-  introspectionQuery,
-  execute as graphql
-} from "graphql";
-
+import { GraphQLError } from "graphql";
 import { toPromise, execute } from "apollo-link";
 
 import { VALIDATE_SCHEMA } from "../../operations/validateSchema";
@@ -89,8 +83,7 @@ export default class SchemaCheck extends Command {
 
           const variables = {
             id: getIdFromKey(ctx.currentSchema.engineKey),
-            schema: (await graphql(ctx.schema, parse(introspectionQuery))).data!
-              .__schema,
+            schema: ctx.schema,
             // XXX hardcoded for now
             tag: "current",
             gitContext

--- a/packages/apollo/src/commands/schema/download.ts
+++ b/packages/apollo/src/commands/schema/download.ts
@@ -10,8 +10,6 @@ import { loadSchema } from "../../load-schema";
 
 import { loadConfigStep } from "../../load-config";
 
-import { execute, introspectionQuery, parse } from "graphql";
-
 export default class SchemaDownload extends Command {
   static description = "Download the schema from your GraphQL endpoint.";
 
@@ -79,11 +77,7 @@ export default class SchemaDownload extends Command {
         task: async ctx => {
           await promisify(fs.writeFile)(
             args.output,
-            JSON.stringify(
-              (await execute(ctx.schema, parse(introspectionQuery))).data!,
-              null,
-              2
-            )
+            JSON.stringify({ __schema: ctx.schema }, null, 2)
           );
         }
       }

--- a/packages/apollo/src/commands/schema/publish.ts
+++ b/packages/apollo/src/commands/schema/publish.ts
@@ -2,20 +2,12 @@ import { Command, flags } from "@oclif/command";
 import { table, styledJSON } from "heroku-cli-util";
 import * as Listr from "listr";
 import { toPromise, execute } from "apollo-link";
-import {
-  GraphQLError,
-  parse,
-  introspectionQuery,
-  execute as graphql
-} from "graphql";
-
+import { GraphQLError } from "graphql";
 import { UPLOAD_SCHEMA } from "../../operations/uploadSchema";
 import { getIdFromKey, engineLink } from "../../engine";
 import { fetchSchema } from "../../fetch-schema";
 import { gitInfo } from "../../git";
-
 import { engineFlags } from "../../engine-cli";
-
 import { loadConfigStep } from "../../load-config";
 
 export default class SchemaPublish extends Command {
@@ -84,8 +76,7 @@ export default class SchemaPublish extends Command {
           )} to Apollo Engine`;
           const gitContext = await gitInfo();
           const variables = {
-            schema: (await graphql(ctx.schema, parse(introspectionQuery))).data!
-              .__schema,
+            schema: ctx.schema,
             tag,
             gitContext,
             id: getIdFromKey(ctx.currentSchema.engineKey)

--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -3,7 +3,13 @@ import { fs, withGlobalFS } from "apollo-codegen-core/lib/localfs";
 
 import * as fg from "glob";
 import * as minimatch from "minimatch";
-import { GraphQLSchema, extendSchema, visit, buildASTSchema } from "graphql";
+import {
+  GraphQLSchema,
+  extendSchema,
+  visit,
+  buildASTSchema,
+  buildClientSchema
+} from "graphql";
 import { loadSchema } from "./load-schema";
 import { loadQueryDocuments } from "apollo-codegen-core/lib/loading";
 
@@ -232,7 +238,10 @@ export async function resolveSchema(
       )
     : referredSchema.clientSide
       ? buildASTSchema(loadAsAST())
-      : await loadSchema(referredSchema, config);
+      : await loadSchema(referredSchema, config).then(introspectionResult => {
+          if (!introspectionResult) return;
+          return buildClientSchema({ __schema: introspectionResult });
+        });
 }
 
 export async function resolveDocumentSets(

--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -238,9 +238,9 @@ export async function resolveSchema(
       )
     : referredSchema.clientSide
       ? buildASTSchema(loadAsAST())
-      : await loadSchema(referredSchema, config).then(introspectionResult => {
-          if (!introspectionResult) return;
-          return buildClientSchema({ __schema: introspectionResult });
+      : await loadSchema(referredSchema, config).then(introspectionSchema => {
+          if (!introspectionSchema) return;
+          return buildClientSchema({ __schema: introspectionSchema });
         });
 }
 

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -81,17 +81,22 @@ export const fetchSchema = async (
     options.fetchOptions = { agent: agent };
   }
 
-  return toPromise(
-    // XXX node-fetch isn't compatible typescript wise here?
+  const { data, errors }: any = await toPromise(
     linkExecute(createHttpLink(options), {
       query: introspection,
       context: { headers }
     })
-  ).then(({ data, errors }: any) => {
-    if (errors)
-      throw new Error(errors.map(({ message }: Error) => message).join("\n"));
-    return buildClientSchema({ __schema: data.__schema });
-  });
+  );
+
+  if (!data) {
+    throw new Error("No data received from server introspection.");
+  }
+
+  if (errors) {
+    throw new Error(errors.map(({ message }: Error) => message).join("\n"));
+  }
+
+  return buildClientSchema({ __schema: data.__schema });
 };
 
 export async function fetchSchemaFromEngine(

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -43,41 +43,45 @@ async function buildIntrospectionSchemaInLocalGraphQLContext(
   return executionResult.data.__schema;
 }
 
-function fromFile(file: string): Promise<IntrospectionSchema | undefined> {
+async function fromFile(
+  file: string
+): Promise<IntrospectionSchema | undefined> {
+  let result;
   try {
-    const result = fs.readFileSync(file, {
+    result = fs.readFileSync(file, {
       encoding: "utf-8"
     });
-    const ext = path.extname(file);
-
-    // an actual introspectionQuery result
-    if (ext === ".json") {
-      const parsed = JSON.parse(result);
-      const schemaData = parsed.data
-        ? parsed.data.__schema
-        : parsed.__schema
-          ? parsed.__schema
-          : parsed;
-
-      return schemaData;
-    }
-
-    if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      return buildIntrospectionSchemaInLocalGraphQLContext(
-        new Source(result, file)
-      );
-    }
-
-    if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
-      return buildIntrospectionSchemaInLocalGraphQLContext(
-        extractDocumentFromJavascript(result)!
-      );
-    }
-
-    return Promise.resolve(undefined);
-  } catch (e) {
-    throw new Error(`Unable to read file ${file}. ${e.message}`);
+  } catch (err) {
+    throw new Error(`Unable to read file ${file}. ${err.message}`);
   }
+
+  const ext = path.extname(file);
+
+  // an actual introspectionQuery result
+  if (ext === ".json") {
+    const parsed = JSON.parse(result);
+    const schemaData = parsed.data
+      ? parsed.data.__schema
+      : parsed.__schema
+        ? parsed.__schema
+        : parsed;
+
+    return schemaData;
+  }
+
+  if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
+    return await buildIntrospectionSchemaInLocalGraphQLContext(
+      new Source(result, file)
+    );
+  }
+
+  if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
+    return await buildIntrospectionSchemaInLocalGraphQLContext(
+      extractDocumentFromJavascript(result)!
+    );
+  }
+
+  return;
 }
 
 export const fetchSchema = async (

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -3,11 +3,13 @@ import { fs } from "apollo-codegen-core/lib/localfs";
 import { execute as linkExecute, toPromise } from "apollo-link";
 import { createHttpLink, HttpLink } from "apollo-link-http";
 import {
-  buildClientSchema,
   buildSchema,
   GraphQLSchema,
-  introspectionQuery,
-  Source
+  getIntrospectionQuery,
+  Source,
+  ExecutionResult,
+  graphql,
+  IntrospectionSchema
 } from "graphql";
 import gql from "graphql-tag";
 import { Agent, AgentOptions } from "https";
@@ -18,11 +20,30 @@ import { EndpointConfig } from "./config";
 import { engineLink, getIdFromKey } from "./engine";
 import { SCHEMA_QUERY } from "./operations/schema";
 
-const introspection = gql(introspectionQuery);
+const introspection = gql(getIntrospectionQuery());
 
-async function fromFile(
-  file: string
-): Promise<GraphQLSchema | undefined> {
+async function buildIntrospectionSchemaInLocalGraphQLContext(
+  source: string | Source
+): Promise<IntrospectionSchema> {
+  const schema: GraphQLSchema = buildSchema(source);
+  const executionResult: ExecutionResult = await graphql(
+    schema,
+    getIntrospectionQuery()
+  );
+
+  if (executionResult.errors) {
+    console.error(executionResult.errors);
+    throw new Error("No data received during introspection query execution.");
+  }
+
+  if (!executionResult.data) {
+    throw new Error("No data received during introspection query execution.");
+  }
+
+  return executionResult.data.__schema;
+}
+
+function fromFile(file: string): Promise<IntrospectionSchema | undefined> {
   try {
     const result = fs.readFileSync(file, {
       encoding: "utf-8"
@@ -38,18 +59,22 @@ async function fromFile(
           ? parsed.__schema
           : parsed;
 
-      return buildClientSchema({ __schema: schemaData });
+      return schemaData;
     }
 
     if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      return buildSchema(new Source(result, file));
+      return buildIntrospectionSchemaInLocalGraphQLContext(
+        new Source(result, file)
+      );
     }
 
     if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
-      return await buildSchema(extractDocumentFromJavascript(result)!);
+      return buildIntrospectionSchemaInLocalGraphQLContext(
+        extractDocumentFromJavascript(result)!
+      );
     }
 
-    return undefined;
+    return Promise.resolve(undefined);
   } catch (e) {
     throw new Error(`Unable to read file ${file}. ${e.message}`);
   }
@@ -58,7 +83,7 @@ async function fromFile(
 export const fetchSchema = async (
   { url, headers, skipSSLValidation }: EndpointConfig,
   projectFolder?: string
-): Promise<GraphQLSchema | undefined> => {
+): Promise<IntrospectionSchema | undefined> => {
   if (!url) throw new Error("No endpoint provided when fetching schema");
   const filePath = projectFolder ? path.resolve(projectFolder, url) : url;
   if (fs.existsSync(filePath)) return fromFile(filePath);
@@ -96,13 +121,13 @@ export const fetchSchema = async (
     throw new Error(errors.map(({ message }: Error) => message).join("\n"));
   }
 
-  return buildClientSchema({ __schema: data.__schema });
+  return data.__schema;
 };
 
 export async function fetchSchemaFromEngine(
   apiKey: string,
   customEngine: string | undefined
-): Promise<GraphQLSchema | undefined> {
+): Promise<IntrospectionSchema | undefined> {
   const variables = {
     id: getIdFromKey(apiKey as string),
     tag: "current"
@@ -119,9 +144,11 @@ export async function fetchSchemaFromEngine(
     })
   );
 
-  if (engineSchema.data && engineSchema.data.service.schema) {
-    return buildClientSchema(engineSchema.data.service.schema);
-  } else {
+  if (!engineSchema.data || !engineSchema.data.service.schema) {
     throw new Error("Unable to get schema from Apollo Engine");
   }
+
+  return buildIntrospectionSchemaInLocalGraphQLContext(
+    engineSchema.data.service.schema
+  );
 }

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -117,12 +117,12 @@ export const fetchSchema = async (
     })
   );
 
-  if (!data) {
-    throw new Error("No data received from server introspection.");
-  }
-
   if (errors) {
     throw new Error(errors.map(({ message }: Error) => message).join("\n"));
+  }
+
+  if (!data) {
+    throw new Error("No data received from server introspection.");
   }
 
   return data.__schema;

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -20,7 +20,7 @@ import { SCHEMA_QUERY } from "./operations/schema";
 
 const introspection = gql(introspectionQuery);
 
-export async function fromFile(
+async function fromFile(
   file: string
 ): Promise<GraphQLSchema | undefined> {
   try {

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -1,6 +1,6 @@
 import { extractDocumentFromJavascript } from "apollo-codegen-core/lib/loading";
 import { fs } from "apollo-codegen-core/lib/localfs";
-import { execute, toPromise } from "apollo-link";
+import { execute as linkExecute, toPromise } from "apollo-link";
 import { createHttpLink, HttpLink } from "apollo-link-http";
 import {
   buildClientSchema,
@@ -83,7 +83,7 @@ export const fetchSchema = async (
 
   return toPromise(
     // XXX node-fetch isn't compatible typescript wise here?
-    execute(createHttpLink(options), {
+    linkExecute(createHttpLink(options), {
       query: introspection,
       context: { headers }
     })
@@ -104,7 +104,7 @@ export async function fetchSchemaFromEngine(
   };
 
   const engineSchema = await toPromise(
-    execute(engineLink, {
+    linkExecute(engineLink, {
       query: SCHEMA_QUERY,
       variables,
       context: {

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -22,7 +22,7 @@ import { SCHEMA_QUERY } from "./operations/schema";
 
 const introspection = gql(getIntrospectionQuery());
 
-async function buildIntrospectionSchemaInLocalGraphQLContext(
+async function buildIntrospectionSchemaFromSDL(
   source: string | Source
 ): Promise<IntrospectionSchema> {
   const schema: GraphQLSchema = buildSchema(source);
@@ -70,13 +70,11 @@ async function fromFile(
   }
 
   if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-    return await buildIntrospectionSchemaInLocalGraphQLContext(
-      new Source(result, file)
-    );
+    return await buildIntrospectionSchemaFromSDL(new Source(result, file));
   }
 
   if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
-    return await buildIntrospectionSchemaInLocalGraphQLContext(
+    return await buildIntrospectionSchemaFromSDL(
       extractDocumentFromJavascript(result)!
     );
   }
@@ -152,7 +150,5 @@ export async function fetchSchemaFromEngine(
     throw new Error("Unable to get schema from Apollo Engine");
   }
 
-  return buildIntrospectionSchemaInLocalGraphQLContext(
-    engineSchema.data.service.schema
-  );
+  return buildIntrospectionSchemaFromSDL(engineSchema.data.service.schema);
 }

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -32,8 +32,10 @@ async function buildIntrospectionSchemaFromSDL(
   );
 
   if (executionResult.errors) {
-    console.error(executionResult.errors);
-    throw new Error("No data received during introspection query execution.");
+    throw new Error(
+      "An error occurred during introspection query execution.\n" +
+        executionResult.errors.map(({ message }: Error) => message).join("\n")
+    );
   }
 
   if (!executionResult.data) {

--- a/packages/apollo/src/helpers/commands/queries/commonTasks.ts
+++ b/packages/apollo/src/helpers/commands/queries/commonTasks.ts
@@ -192,6 +192,6 @@ const taskGenerateManifest = ({ flags }: { flags: any }): ListrTask => ({
   }
 });
 
-export function getCommonManifestTasks(flags: any): ListrTask[] {
-  return [taskGenerateManifest(flags)];
+export function getCommonManifestTasks({ flags }: { flags: any }): ListrTask[] {
+  return [taskGenerateManifest({ flags })];
 }

--- a/packages/apollo/src/load-schema.ts
+++ b/packages/apollo/src/load-schema.ts
@@ -1,11 +1,11 @@
-import { GraphQLSchema } from "graphql";
+import { IntrospectionSchema } from "graphql";
 import { ApolloConfig, SchemaDependency } from "./config";
 import { fetchSchema, fetchSchemaFromEngine } from "./fetch-schema";
 
 export async function loadSchema(
   dependency: SchemaDependency,
   config: ApolloConfig
-): Promise<GraphQLSchema | undefined> {
+): Promise<IntrospectionSchema | undefined> {
   if (dependency.schema) {
     return await fetchSchema({ url: dependency.schema }, config.projectFolder);
   } else if (dependency.endpoint && dependency.endpoint.url) {

--- a/packages/apollo/src/load-schema.ts
+++ b/packages/apollo/src/load-schema.ts
@@ -7,28 +7,15 @@ export async function loadSchema(
   config: ApolloConfig
 ): Promise<GraphQLSchema | undefined> {
   if (dependency.schema) {
-    try {
-      return await fetchSchema(
-        { url: dependency.schema },
-        config.projectFolder
-      );
-    } catch {}
+    return await fetchSchema({ url: dependency.schema }, config.projectFolder);
+  } else if (dependency.endpoint && dependency.endpoint.url) {
+    return await fetchSchema(dependency.endpoint, config.projectFolder);
+  } else if (dependency.engineKey) {
+    return await fetchSchemaFromEngine(
+      dependency.engineKey,
+      config.engineEndpoint
+    );
+  } else {
+    return undefined;
   }
-
-  if (dependency.endpoint && dependency.endpoint.url) {
-    try {
-      return await fetchSchema(dependency.endpoint, config.projectFolder);
-    } catch {}
-  }
-
-  if (dependency.engineKey) {
-    try {
-      return await fetchSchemaFromEngine(
-        dependency.engineKey,
-        config.engineEndpoint
-      );
-    } catch {}
-  }
-
-  return undefined;
 }


### PR DESCRIPTION
~**Note:** This PR depends on #611 and #613 and merges into #611.  If #611 lands first, this should be re-targeted to land in `master`.~

---

The commits in this PR avoid re-running the introspection result from a GraphQL server as a client schema when not necessary.  This is particularly important to maintain an introspection result which is consistent with the version of `graphql` which is used on the actual GraphQL server being introspected.  Previously, this was re-running that introspection in the Apollo CLI’s `graphql` executor which produced a different result since there is no guarantee that the server is using `graphql@0.13.2`, the version currently used by the `apollo` CLI.

Additionally, thanks to @jbaxleyiii’s work in 88a248c, operations in the manifest now properly consider common dynamic transformations to operations like client-only directives (e.g. `@client`, `@connection`) and additions of `__typename` fields, as is common under normal Apollo Client use.