### PR TITLE
VSCode: Schema tag switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8808,6 +8808,12 @@
         "semver": "^5.5.0"
       }
     },
+    "node-cleanup": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
@@ -9928,6 +9934,15 @@
       "dev": true,
       "requires": {
         "genfun": "^4.0.1"
+      }
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -11538,6 +11553,39 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "tsc-watch": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-1.0.30.tgz",
+      "integrity": "sha512-y4aIyRnzSof+614TIxEU14ZBAH5xbn9rrO4Sb/vXlSeEcNIeYIRbn33gjdtuiwiKKmMw3/hhd7FSm57r0mRa4g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "cross-spawn": "^5.1.0",
+        "node-cleanup": "^2.1.2",
+        "ps-tree": "^1.1.0",
+        "string-argv": "^0.1.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "string-argv": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.1.tgz",
+          "integrity": "sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,6 +1899,8 @@
     "apollo-vscode": {
       "version": "file:packages/apollo-vscode",
       "requires": {
+        "apollo": "file:packages/apollo",
+        "dotenv": "^6.1.0",
         "vscode": "^1.1.21",
         "vscode-languageclient": "^5.0.1"
       }
@@ -4081,6 +4083,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "prettier": "1.14.2",
     "ts-jest": "^23.1.4",
     "ts-node": "^7.0.1",
+    "tsc-watch": "^1.0.30",
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",
     "vsce": "^1.46.0"

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -17,9 +17,9 @@
     "installServer": "installServerIntoExtension ../apollo-vscode ./package.json ./tsconfig.json && ./copy-apollo-libs.sh",
     "clean": "rm -rf ../apollo-vscode/server",
     "prebuild": "npm run clean",
-    "build": "npm run installServer && tsc -p .",
-    "watch": "npm run installServer && tsc -w -p .",
-    "watchOnly": "tsc -w -p .",
+    "build": "npm run installServer && tsc",
+    "watch": "npm run installServer && tsc-watch --onSuccess \"./copy-apollo-libs.sh\"",
+    "watchOnly": "tsc -w",
     "prepare": "npm run build"
   },
   "engines": {

--- a/packages/apollo-language-server/src/loadingHandler.ts
+++ b/packages/apollo-language-server/src/loadingHandler.ts
@@ -1,0 +1,52 @@
+import { IConnection, NotificationType } from "vscode-languageserver";
+
+export class LoadingHandler {
+  constructor(private connection: IConnection) {}
+  private latestLoadingToken = 0;
+  async handle<T>(message: string, value: Promise<T>): Promise<T> {
+    const token = this.latestLoadingToken;
+    this.latestLoadingToken += 1;
+    this.connection.sendNotification(
+      new NotificationType<any, void>("apollographql/loading"),
+      { message, token }
+    );
+    try {
+      const ret = await value;
+      this.connection.sendNotification(
+        new NotificationType<any, void>("apollographql/loadingComplete"),
+        token
+      );
+      return ret;
+    } catch (e) {
+      this.connection.sendNotification(
+        new NotificationType<any, void>("apollographql/loadingComplete"),
+        token
+      );
+      this.connection.window.showErrorMessage(`Error in "${message}": ${e}`);
+      throw e;
+    }
+  }
+  handleSync<T>(message: string, value: () => T): T {
+    const token = this.latestLoadingToken;
+    this.latestLoadingToken += 1;
+    this.connection.sendNotification(
+      new NotificationType<any, void>("apollographql/loading"),
+      { message, token }
+    );
+    try {
+      const ret = value();
+      this.connection.sendNotification(
+        new NotificationType<any, void>("apollographql/loadingComplete"),
+        token
+      );
+      return ret;
+    } catch (e) {
+      this.connection.sendNotification(
+        new NotificationType<any, void>("apollographql/loadingComplete"),
+        token
+      );
+      this.connection.window.showErrorMessage(`Error in "${message}": ${e}`);
+      throw e;
+    }
+  }
+}

--- a/packages/apollo-language-server/src/loadingHandler.ts
+++ b/packages/apollo-language-server/src/loadingHandler.ts
@@ -22,7 +22,7 @@ export class LoadingHandler {
         new NotificationType<any, void>("apollographql/loadingComplete"),
         token
       );
-      this.connection.window.showErrorMessage(`Error in "${message}": ${e}`);
+      this.showError(`Error in "${message}": ${e}`);
       throw e;
     }
   }
@@ -45,8 +45,11 @@ export class LoadingHandler {
         new NotificationType<any, void>("apollographql/loadingComplete"),
         token
       );
-      this.connection.window.showErrorMessage(`Error in "${message}": ${e}`);
+      this.showError(`Error in "${message}": ${e}`);
       throw e;
     }
+  }
+  showError(message: string) {
+    this.connection.window.showErrorMessage(message);
   }
 }

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -89,6 +89,16 @@ const engineStatsQuery = gql`
   }
 `;
 
+const schemaTagsQuery = gql`
+  query SchemaTags($id: ID!) {
+    service(id: $id) {
+      schemaTags {
+        tag
+      }
+    }
+  }
+`;
+
 export interface DocumentAndSet {
   doc: GraphQLDocument;
   set: ResolvedDocumentSet;
@@ -98,6 +108,7 @@ export class GraphQLProject {
   public config: ApolloConfig = (null as any) as ApolloConfig;
   private _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
   private _onDecorations?: (any: any) => void;
+  private _onSchemaTags?: (tags: Map<string, string[]>) => void;
 
   public isReady = false;
   public readyPromise: Promise<void> | undefined = undefined;
@@ -113,6 +124,7 @@ export class GraphQLProject {
     string,
     Map<string, Map<string, number>>
   > = new Map();
+  private schemaTags: Map<string, string[]> = new Map();
 
   constructor(
     config: ApolloConfig,
@@ -135,6 +147,7 @@ export class GraphQLProject {
 
     this.documentSets = undefined;
     this.engineStats.clear();
+    this.schemaTags = new Map();
     this.documentsByFile = new Map();
     this.setToResolved.clear();
 
@@ -143,10 +156,18 @@ export class GraphQLProject {
       .catch(error => {
         console.error(error);
       });
+
+    this.loadSchemaTags().then(() => {
+      this._onSchemaTags && this._onSchemaTags(this.schemaTags);
+    });
   }
 
   get displayName(): string {
     return this.config.name || "";
+  }
+
+  onSchemaTags(handler: (tags: Map<string, string[]>) => void): void {
+    this._onSchemaTags = handler;
   }
 
   onDiagnostics(handler: NotificationHandler<PublishDiagnosticsParams>) {
@@ -177,6 +198,38 @@ export class GraphQLProject {
 
   private includesPath(filePath: string) {
     return !!this.setThatIncludes(filePath);
+  }
+
+  async loadSchemaTags() {
+    await this.loadingHandler.handle(
+      `Loading available schema tags for ${this.config.name!}`,
+      Promise.all(
+        Object.values(this.config.schemas!).map(async schemaDef => {
+          if (schemaDef.engineKey) {
+            const tagsResult = await toPromise(
+              execute(engineLink, {
+                query: schemaTagsQuery,
+                variables: {
+                  id: getIdFromKey(schemaDef.engineKey!)
+                },
+                context: {
+                  headers: { ["x-api-key"]: schemaDef.engineKey },
+                  ...(this.config.engineEndpoint && {
+                    uri: this.config.engineEndpoint
+                  })
+                }
+              })
+            );
+
+            const flattenedResult: string[] = tagsResult.data!.service.schemaTags.map(
+              ({ tag }: { tag: string }) => tag
+            );
+
+            this.schemaTags.set(schemaDef.engineKey, flattenedResult);
+          }
+        })
+      )
+    );
   }
 
   async loadEngineStats() {
@@ -241,12 +294,50 @@ export class GraphQLProject {
     );
   }
 
+  async updateSchemaTag(tag: string) {
+    await this.loadingHandler.handle(
+      `Loading queries and schemas for ${this.config.name!}`,
+      (async () => {
+        this.documentSets = await resolveDocumentSets(this.config, true, tag);
+        for (const set of this.documentSets) {
+          if (!set.schema!.getQueryType()!.astNode) {
+            const schemaSource = printSchema(set.schema!);
+
+            set.schema = buildSchema(
+              // rebuild the schema from a generated source file and attach the source to a graphql-schema
+              // URI that can be loaded as an in-memory file by VSCode
+              new Source(
+                schemaSource,
+                `graphql-schema:/schema.graphql?${encodeURIComponent(
+                  schemaSource
+                )}`
+              )
+            );
+          }
+
+          this.setToResolved.set(set.originalSet, set);
+
+          for (const filePath of set.documentPaths) {
+            const uri = Uri.file(filePath).toString();
+            this.fileDidChange(uri, set);
+          }
+        }
+
+        this.isReady = true;
+        this.validateIfNeeded();
+      })()
+    );
+  }
+
   async scanAllIncludedFiles() {
     await this.loadingHandler.handle(
       `Loading queries and schemas for ${this.config.name!}`,
       (async () => {
-        console.time(`scanAllIncludedFiles - ${this.displayName}`);
-        this.documentSets = await resolveDocumentSets(this.config, true);
+        this.documentSets = await resolveDocumentSets(
+          this.config,
+          true,
+          "current"
+        );
 
         for (const set of this.documentSets) {
           if (!set.schema!.getQueryType()!.astNode) {
@@ -276,8 +367,6 @@ export class GraphQLProject {
             this.fileDidChange(uri, set);
           }
         }
-
-        console.timeEnd(`scanAllIncludedFiles - ${this.displayName}`);
 
         this.isReady = true;
         this.validateIfNeeded();

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -210,7 +210,7 @@ export class GraphQLProject {
               execute(engineLink, {
                 query: schemaTagsQuery,
                 variables: {
-                  id: getIdFromKey(schemaDef.engineKey!)
+                  id: getIdFromKey(schemaDef.engineKey)
                 },
                 context: {
                   headers: { ["x-api-key"]: schemaDef.engineKey },
@@ -242,7 +242,7 @@ export class GraphQLProject {
               execute(engineLink, {
                 query: engineStatsQuery,
                 variables: {
-                  id: getIdFromKey(schemaDef.engineKey!)
+                  id: getIdFromKey(schemaDef.engineKey)
                 },
                 context: {
                   headers: { ["x-api-key"]: schemaDef.engineKey },

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -52,7 +52,7 @@ export type DocumentUri = string;
 import "core-js/fn/array/flat-map";
 import { rangeForASTNode } from "./utilities/source";
 import { formatMS } from "./format";
-import { LoadingHandler } from "./server";
+import { LoadingHandler } from "./loadingHandler";
 declare global {
   interface Array<T> {
     flatMap<U>(

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -265,13 +265,18 @@ export class GraphQLProject {
     );
   }
 
+  private documentSetHasAstNode(set: ResolvedDocumentSet): boolean {
+    const queryType = set && set.schema && set.schema.getQueryType();
+    return !!(queryType && queryType.astNode);
+  }
+
   async updateSchemaTag(tag: string) {
     await this.loadingHandler.handle(
       `Loading queries and schemas for ${this.config.name!}`,
       (async () => {
         this.documentSets = await resolveDocumentSets(this.config, true, tag);
         for (const set of this.documentSets) {
-          if (!set.schema!.getQueryType()!.astNode) {
+          if (!this.documentSetHasAstNode(set)) {
             const schemaSource = printSchema(set.schema!);
 
             set.schema = buildSchema(
@@ -311,7 +316,7 @@ export class GraphQLProject {
         );
 
         for (const set of this.documentSets) {
-          if (!set.schema!.getQueryType()!.astNode) {
+          if (!this.documentSetHasAstNode(set)) {
             const schemaSource = printSchema(set.schema!);
 
             set.schema = buildSchema(

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -3,73 +3,20 @@ import {
   createConnection,
   ProposedFeatures,
   TextDocuments,
-  FileChangeType,
-  NotificationType
+  FileChangeType
 } from "vscode-languageserver";
 import { QuickPickItem } from "vscode";
 import Uri from "vscode-uri";
 import { findAndLoadConfig } from "apollo/lib/config";
 import { GraphQLWorkspace } from "./workspace";
 import { GraphQLLanguageProvider } from "./languageProvider";
+import { LoadingHandler } from "./loadingHandler";
 
 const connection = createConnection(ProposedFeatures.all);
 
 let hasWorkspaceFolderCapability = false;
 
-export class LoadingHandler {
-  private latestLoadingToken = 0;
-  async handle<T>(message: string, value: Promise<T>): Promise<T> {
-    const token = this.latestLoadingToken;
-    this.latestLoadingToken += 1;
-    connection.sendNotification(
-      new NotificationType<any, void>("apollographql/loading"),
-      { message, token }
-    );
-
-    try {
-      const ret = await value;
-      connection.sendNotification(
-        new NotificationType<any, void>("apollographql/loadingComplete"),
-        token
-      );
-      return ret;
-    } catch (e) {
-      connection.sendNotification(
-        new NotificationType<any, void>("apollographql/loadingComplete"),
-        token
-      );
-      connection.window.showErrorMessage(`Error in "${message}": ${e}`);
-      throw e;
-    }
-  }
-
-  handleSync<T>(message: string, value: () => T): T {
-    const token = this.latestLoadingToken;
-    this.latestLoadingToken += 1;
-    connection.sendNotification(
-      new NotificationType<any, void>("apollographql/loading"),
-      { message, token }
-    );
-
-    try {
-      const ret = value();
-      connection.sendNotification(
-        new NotificationType<any, void>("apollographql/loadingComplete"),
-        token
-      );
-      return ret;
-    } catch (e) {
-      connection.sendNotification(
-        new NotificationType<any, void>("apollographql/loadingComplete"),
-        token
-      );
-      connection.window.showErrorMessage(`Error in "${message}": ${e}`);
-      throw e;
-    }
-  }
-}
-
-const workspace = new GraphQLWorkspace(new LoadingHandler());
+const workspace = new GraphQLWorkspace(new LoadingHandler(connection));
 
 workspace.onSchemaTags((tags: Map<string, string[]>) => {
   connection.sendNotification(
@@ -86,19 +33,18 @@ workspace.onDecorations(decs => {
   connection.sendNotification("apollographql/engineDecorations", decs);
 });
 
-const hasInitializedPromise = new Promise(resolve => {
-  connection.onInitialized(async () => {
-    resolve();
+let initialize: () => void;
+const whenInitialized = new Promise<void>(resolve => (initialize = resolve));
 
-    if (hasWorkspaceFolderCapability) {
-      connection.workspace.onDidChangeWorkspaceFolders(event => {
-        event.removed.forEach(folder =>
-          workspace.removeProjectsInFolder(folder)
-        );
-        event.added.forEach(folder => workspace.addProjectsInFolder(folder));
-      });
-    }
-  });
+connection.onInitialized(async () => {
+  initialize();
+
+  if (hasWorkspaceFolderCapability) {
+    connection.workspace.onDidChangeWorkspaceFolders(event => {
+      event.removed.forEach(folder => workspace.removeProjectsInFolder(folder));
+      event.added.forEach(folder => workspace.addProjectsInFolder(folder));
+    });
+  }
 });
 
 connection.onInitialize(async params => {
@@ -109,7 +55,7 @@ connection.onInitialize(async params => {
 
   const workspaceFolders = params.workspaceFolders;
   if (workspaceFolders) {
-    hasInitializedPromise.then(() => {
+    whenInitialized.then(() => {
       workspaceFolders.forEach(folder => workspace.addProjectsInFolder(folder));
     });
   }
@@ -196,42 +142,38 @@ connection.onDidChangeWatchedFiles(params => {
 
 const languageProvider = new GraphQLLanguageProvider(workspace);
 
-connection.onHover((params, token) => {
-  return languageProvider.provideHover(
+connection.onHover((params, token) =>
+  languageProvider.provideHover(params.textDocument.uri, params.position, token)
+);
+
+connection.onDefinition((params, token) =>
+  languageProvider.provideDefinition(
     params.textDocument.uri,
     params.position,
     token
-  );
-});
+  )
+);
 
-connection.onDefinition((params, token) => {
-  return languageProvider.provideDefinition(
-    params.textDocument.uri,
-    params.position,
-    token
-  );
-});
-
-connection.onReferences((params, token) => {
-  return languageProvider.provideReferences(
+connection.onReferences((params, token) =>
+  languageProvider.provideReferences(
     params.textDocument.uri,
     params.position,
     params.context,
     token
-  );
-});
+  )
+);
 
-connection.onCompletion((params, token) => {
-  return languageProvider.provideCompletionItems(
+connection.onCompletion((params, token) =>
+  languageProvider.provideCompletionItems(
     params.textDocument.uri,
     params.position,
     token
-  );
-});
+  )
+);
 
-connection.onCodeLens((params, token) => {
-  return languageProvider.provideCodeLenses(params.textDocument.uri, token);
-});
+connection.onCodeLens((params, token) =>
+  languageProvider.provideCodeLenses(params.textDocument.uri, token)
+);
 
 connection.onNotification(
   "apollographql/tagSelected",

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -6,6 +6,7 @@ import {
   FileChangeType,
   NotificationType
 } from "vscode-languageserver";
+import { QuickPickItem } from "vscode";
 import Uri from "vscode-uri";
 import { findAndLoadConfig } from "apollo/lib/config";
 import { GraphQLWorkspace } from "./workspace";
@@ -69,6 +70,13 @@ export class LoadingHandler {
 }
 
 const workspace = new GraphQLWorkspace(new LoadingHandler());
+
+workspace.onSchemaTags((tags: Map<string, string[]>) => {
+  connection.sendNotification(
+    "apollographql/tagsLoaded",
+    JSON.stringify([...tags])
+  );
+});
 
 workspace.onDiagnostics(params => {
   connection.sendDiagnostics(params);
@@ -224,5 +232,10 @@ connection.onCompletion((params, token) => {
 connection.onCodeLens((params, token) => {
   return languageProvider.provideCodeLenses(params.textDocument.uri, token);
 });
+
+connection.onNotification(
+  "apollographql/tagSelected",
+  (selection: QuickPickItem) => workspace.updateSchemaTag(selection)
+);
 
 connection.listen();

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -12,7 +12,7 @@ import * as fg from "glob";
 import { findAndLoadConfig } from "apollo/lib/config";
 import { GraphQLDocument } from "./document";
 import { Source, buildSchema } from "graphql";
-import { LoadingHandler } from "./server";
+import { LoadingHandler } from "./loadingHandler";
 
 export class GraphQLWorkspace {
   private _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -4,6 +4,7 @@ import {
   PublishDiagnosticsParams
 } from "vscode-languageserver";
 import Uri from "vscode-uri";
+import { QuickPickItem } from "vscode";
 
 import { GraphQLProject, DocumentUri } from "./project";
 import { dirname } from "path";
@@ -16,6 +17,7 @@ import { LoadingHandler } from "./server";
 export class GraphQLWorkspace {
   private _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
   private _onDecorations?: (any: any) => void;
+  private _onSchemaTags?: (tags: Map<string, string[]>) => void;
   public projectsByFolderUri: Map<string, GraphQLProject[]> = new Map();
 
   constructor(private loadingHandler: LoadingHandler) {}
@@ -26,6 +28,10 @@ export class GraphQLWorkspace {
 
   onDecorations(handler: (any: any) => void) {
     this._onDecorations = handler;
+  }
+
+  onSchemaTags(handler: (tags: Map<string, string[]>) => void): void {
+    this._onSchemaTags = handler;
   }
 
   addProjectsInFolder(folder: WorkspaceFolder) {
@@ -70,6 +76,10 @@ export class GraphQLWorkspace {
         this.loadingHandler
       );
 
+      project.onSchemaTags((tags: Map<string, string[]>) => {
+        this._onSchemaTags && this._onSchemaTags(tags);
+      });
+
       project.onDiagnostics(params => {
         this._onDiagnostics && this._onDiagnostics(params);
       });
@@ -82,6 +92,19 @@ export class GraphQLWorkspace {
     });
 
     this.projectsByFolderUri.set(folder.uri, projects);
+  }
+
+  updateSchemaTag(selection: QuickPickItem) {
+    this.projectsByFolderUri.forEach(projects => {
+      projects.forEach(project => {
+        const projectConsumesService = project.config.schemas!.default.engineKey!.includes(
+          selection.detail!
+        );
+        if (projectConsumesService) {
+          project.updateSchemaTag(selection.label);
+        }
+      });
+    });
   }
 
   removeProjectsInFolder(folder: WorkspaceFolder) {

--- a/packages/apollo-vscode/package-lock.json
+++ b/packages/apollo-vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-vscode",
-  "version": "0.1.5",
+  "version": "0.1.6-register.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -271,6 +271,11 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+    },
+    "dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/packages/apollo-vscode/package.json
+++ b/packages/apollo-vscode/package.json
@@ -76,6 +76,11 @@
           "meta.embedded.block.graphql": "graphql"
         }
       }
-    ]
+    ],
+    "commands": [{
+      "command": "apollographql/selectSchemaTag",
+      "title": "Select Schema Tag",
+      "category": "Apollo"
+  }]
   }
 }

--- a/packages/apollo-vscode/package.json
+++ b/packages/apollo-vscode/package.json
@@ -28,6 +28,8 @@
     "vscode": "^1.26.0"
   },
   "dependencies": {
+    "apollo": "file:../apollo",
+    "dotenv": "^6.1.0",
     "vscode": "^1.1.21",
     "vscode-languageclient": "^5.0.1"
   },

--- a/packages/apollo-vscode/src/extension.ts
+++ b/packages/apollo-vscode/src/extension.ts
@@ -92,11 +92,10 @@ export function activate(context: ExtensionContext) {
         );
 
         schemaTags = [...quickPickItems, ...schemaTags];
-        statusBar.enableClickHandler(true);
       }
     );
 
-    commands.registerCommand("launchSchemaTagPicker", async () => {
+    commands.registerCommand("apollographql/selectSchemaTag", async () => {
       const selection = await window.showQuickPick(schemaTags);
       if (selection) {
         client.sendNotification("apollographql/tagSelected", selection);

--- a/packages/apollo-vscode/src/extension.ts
+++ b/packages/apollo-vscode/src/extension.ts
@@ -1,11 +1,14 @@
-import { join } from "path";
+import { join, resolve } from "path";
+import { readFileSync } from "fs";
 import {
   window,
   workspace,
   ExtensionContext,
   Uri,
   ProgressLocation,
-  DecorationOptions
+  DecorationOptions,
+  commands,
+  QuickPickItem
 } from "vscode";
 import {
   LanguageClient,
@@ -13,11 +16,24 @@ import {
   ServerOptions,
   TransportKind
 } from "vscode-languageclient";
-import StatusBar from "./StatusBar";
+import { getIdFromKey } from "apollo/lib/engine";
+import StatusBar from "./statusBar";
+
+// Parse the .env file and load the ENGINE_API_KEY into process.env
+const env: { [key: string]: string } = workspace.rootPath
+  ? require("dotenv").parse(readFileSync(resolve(workspace.rootPath, ".env")))
+  : {};
+
+const key = "ENGINE_API_KEY";
+if (env[key]) {
+  process.env[key] = env[key];
+}
 
 export function activate(context: ExtensionContext) {
   const serverModule = context.asAbsolutePath(join("server", "server.js"));
   const debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
+  const statusBar = new StatusBar();
+  let schemaTags: QuickPickItem[] = [];
 
   const serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.ipc },
@@ -45,8 +61,6 @@ export function activate(context: ExtensionContext) {
     }
   };
 
-  const statusBar = new StatusBar();
-
   const client = new LanguageClient(
     "apollographql",
     "Apollo GraphQL",
@@ -57,6 +71,38 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(client.start());
 
   client.onReady().then(() => {
+    // For some reason, non-strings can only be sent in one direction. For now, messages
+    // coming from the language server just need to be stringified and parsed.
+    client.onNotification(
+      "apollographql/tagsLoaded",
+      (stringifiedTags: string) => {
+        const parsedTags: [string, string[]][] =
+          JSON.parse(stringifiedTags) || [];
+
+        const quickPickItems = parsedTags.reduce(
+          (flattenedTags: QuickPickItem[], [serviceId, tags]) => [
+            ...flattenedTags,
+            ...tags.map(tag => ({
+              label: tag,
+              description: "",
+              detail: getIdFromKey(serviceId)
+            }))
+          ],
+          []
+        );
+
+        schemaTags = [...quickPickItems, ...schemaTags];
+        statusBar.enableClickHandler(true);
+      }
+    );
+
+    commands.registerCommand("launchSchemaTagPicker", async () => {
+      const selection = await window.showQuickPick(schemaTags);
+      if (selection) {
+        client.sendNotification("apollographql/tagSelected", selection);
+      }
+    });
+
     let currentLoadingResolve: Map<number, () => void> = new Map();
 
     client.onNotification("apollographql/loadingComplete", token => {

--- a/packages/apollo-vscode/src/statusBar.ts
+++ b/packages/apollo-vscode/src/statusBar.ts
@@ -20,6 +20,13 @@ export default class ApolloStatusBar {
     this.statusBarItem.show();
   }
 
+  public enableClickHandler(isEnabled: boolean) {
+    this.statusBarItem.tooltip = isEnabled ? "Select schema tag" : undefined;
+    this.statusBarItem.command = isEnabled
+      ? "launchSchemaTagPicker"
+      : undefined;
+  }
+
   public dispose() {
     this.statusBarItem.dispose();
   }

--- a/packages/apollo-vscode/src/statusBar.ts
+++ b/packages/apollo-vscode/src/statusBar.ts
@@ -20,13 +20,6 @@ export default class ApolloStatusBar {
     this.statusBarItem.show();
   }
 
-  public enableClickHandler(isEnabled: boolean) {
-    this.statusBarItem.tooltip = isEnabled ? "Select schema tag" : undefined;
-    this.statusBarItem.command = isEnabled
-      ? "launchSchemaTagPicker"
-      : undefined;
-  }
-
   public dispose() {
     this.statusBarItem.dispose();
   }

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -5,17 +5,19 @@
 Apollo CLI brings together your GraphQL clients and servers with tools for validating your schema, linting your operations for compatibility with your server, and generating static types for improved client-side type safety.
 
 <!-- toc -->
-* [Apollo CLI](#apollo-cli)
-* [Usage](#usage)
-* [Commands](#commands)
-* [Configuration](#configuration)
-* [Code Generation](#code-generation)
-* [Contributing](#contributing)
-<!-- tocstop -->
+
+- [Apollo CLI](#apollo-cli)
+- [Usage](#usage)
+- [Commands](#commands)
+- [Configuration](#configuration)
+- [Code Generation](#code-generation)
+- [Contributing](#contributing)
+  <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g apollo
 $ apollo COMMAND
@@ -27,18 +29,20 @@ USAGE
   $ apollo COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`apollo codegen:generate [OUTPUT]`](#apollo-codegengenerate-output)
-* [`apollo help [COMMAND]`](#apollo-help-command)
-* [`apollo queries:check`](#apollo-queriescheck)
-* [`apollo queries:extract OUTPUT`](#apollo-queriesextract-output)
-* [`apollo schema:check`](#apollo-schemacheck)
-* [`apollo schema:download OUTPUT`](#apollo-schemadownload-output)
-* [`apollo schema:publish`](#apollo-schemapublish)
+
+- [`apollo codegen:generate [OUTPUT]`](#apollo-codegengenerate-output)
+- [`apollo help [COMMAND]`](#apollo-help-command)
+- [`apollo queries:check`](#apollo-queriescheck)
+- [`apollo queries:extract OUTPUT`](#apollo-queriesextract-output)
+- [`apollo schema:check`](#apollo-schemacheck)
+- [`apollo schema:download OUTPUT`](#apollo-schemadownload-output)
+- [`apollo schema:publish`](#apollo-schemapublish)
 
 ## `apollo codegen:generate [OUTPUT]`
 
@@ -230,9 +234,11 @@ OPTIONS
   --header=header      Additional headers to send to server for introspectionQuery
   --json               Output successful publish result as JSON
   --key=key            The API key for the Apollo Engine service
+  --tag=tag            The tag to publish the schema to
 ```
 
 _See code: [src/commands/schema/publish.ts](https://github.com/apollographql/apollo-cli/blob/master/packages/apollo/src/commands/schema/publish.ts)_
+
 <!-- commandsstop -->
 
 # Configuration
@@ -458,9 +464,9 @@ It can also be helpful to print standard out during testing. To enable logging, 
 
 ## Publishing
 
-* Before publishing, check the `CHANGELOG.md` in the root of the repository and make sure it's up to date.
-* Make sure you have a `GITHUB_TOKEN` set in your environment variables.  For more information on setting `GITHUB_AUTH`, check the [`lerna-changelog` documentation](https://github.com/lerna/lerna-changelog#github-token).
-* In the root of the repository, run `npx lerna-changelog` (PR labels are read automatically using the `GITHUB_AUTH` token).
-* Copy the result into the `CHANGELOG.md` file and replace the top line with the CLI version that will be published.
-* Run `git add CHANGELOG.md` so that the update will be included in Lerna's "publish" commit.
-* Finally, run `npm run release` to publish the individual packages.
+- Before publishing, check the `CHANGELOG.md` in the root of the repository and make sure it's up to date.
+- Make sure you have a `GITHUB_TOKEN` set in your environment variables. For more information on setting `GITHUB_AUTH`, check the [`lerna-changelog` documentation](https://github.com/lerna/lerna-changelog#github-token).
+- In the root of the repository, run `npx lerna-changelog` (PR labels are read automatically using the `GITHUB_AUTH` token).
+- Copy the result into the `CHANGELOG.md` file and replace the top line with the CLI version that will be published.
+- Run `git add CHANGELOG.md` so that the update will be included in Lerna's "publish" commit.
+- Finally, run `npm run release` to publish the individual packages.

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf lib",
     "prebuild": "npm run clean",
     "build": "tsc",
-    "watch": "tsc -w",
+    "watch": "tsc-watch --onSuccess \"cp -r . ../apollo-vscode/server/node_modules/apollo\"",
     "prepare": "npm run build",
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",

--- a/packages/apollo/src/commands/schema/download.ts
+++ b/packages/apollo/src/commands/schema/download.ts
@@ -66,10 +66,10 @@ export default class SchemaDownload extends Command {
             this.error("No schemas found.");
           }
 
-          ctx.schema = await loadSchema(
-            Object.values(ctx.config.schemas)[0],
-            ctx.config
-          );
+          ctx.schema = await loadSchema({
+            dependency: Object.values(ctx.config.schemas)[0],
+            config: ctx.config
+          });
         }
       },
       {

--- a/packages/apollo/src/commands/schema/publish.ts
+++ b/packages/apollo/src/commands/schema/publish.ts
@@ -35,13 +35,15 @@ export default class SchemaPublish extends Command {
     }),
     json: flags.boolean({
       description: "Output successful publish result as JSON"
+    }),
+    tag: flags.string({
+      description: "The tag to publish the schema to",
+      default: "current"
     })
   };
 
   async run() {
     const { flags } = this.parse(SchemaPublish);
-    // hardcoded to current until service / schema / tag is settled
-    const tag = "current";
 
     const tasks = new Listr([
       loadConfigStep(flags, true),
@@ -77,7 +79,7 @@ export default class SchemaPublish extends Command {
           const gitContext = await gitInfo();
           const variables = {
             schema: ctx.schema,
-            tag,
+            tag: flags.tag,
             gitContext,
             id: getIdFromKey(ctx.currentSchema.engineKey)
           };

--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -82,7 +82,7 @@ function loadSchemaConfig(
       obj.endpoint,
       !obj.engineKey && defaultEndpoint
     ),
-    engineKey: obj.engineKey,
+    engineKey: obj.engineKey || process.env.ENGINE_API_KEY,
     clientSide: obj.clientSide,
     extends: obj.extends
   };

--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -238,17 +238,23 @@ export async function resolveSchema({
 
   return referredSchema.extends
     ? extendSchema(
-        (await resolveSchema({ name: referredSchema.extends, config, tag }))!,
+        (await resolveSchema({
+          name: referredSchema.extends,
+          config,
+          ...(tag && { tag })
+        }))!,
         loadAsAST()
       )
     : referredSchema.clientSide
       ? buildASTSchema(loadAsAST())
-      : await loadSchema({ dependency: referredSchema, config, tag }).then(
-          introspectionSchema => {
-            if (!introspectionSchema) return;
-            return buildClientSchema({ __schema: introspectionSchema });
-          }
-        );
+      : await loadSchema({
+          dependency: referredSchema,
+          config,
+          ...(tag && { tag })
+        }).then(introspectionSchema => {
+          if (!introspectionSchema) return;
+          return buildClientSchema({ __schema: introspectionSchema });
+        });
 }
 
 export async function resolveDocumentSets(
@@ -275,7 +281,11 @@ export async function resolveDocumentSets(
       return {
         schema:
           needSchema && doc.schema
-            ? await resolveSchema({ name: doc.schema, config, tag })
+            ? await resolveSchema({
+                name: doc.schema,
+                config,
+                ...(tag && { tag })
+              })
             : undefined,
         endpoint: referredSchema ? referredSchema.endpoint : undefined,
         engineKey: referredSchema ? referredSchema.engineKey : undefined,

--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -82,7 +82,7 @@ function loadSchemaConfig(
       obj.endpoint,
       !obj.engineKey && defaultEndpoint
     ),
-    engineKey: obj.engineKey || process.env.ENGINE_API_KEY,
+    engineKey: process.env.ENGINE_API_KEY || obj.engineKey,
     clientSide: obj.clientSide,
     extends: obj.extends
   };

--- a/packages/apollo/src/fetch-schema.ts
+++ b/packages/apollo/src/fetch-schema.ts
@@ -128,13 +128,18 @@ export const fetchSchema = async (
   return data.__schema;
 };
 
-export async function fetchSchemaFromEngine(
-  apiKey: string,
-  customEngine: string | undefined
-): Promise<IntrospectionSchema | undefined> {
+export async function fetchSchemaFromEngine({
+  apiKey,
+  tag = "current",
+  customEngine
+}: {
+  apiKey: string;
+  tag?: string;
+  customEngine?: string;
+}): Promise<IntrospectionSchema | undefined> {
   const variables = {
     id: getIdFromKey(apiKey as string),
-    tag: "current"
+    tag
   };
 
   const engineSchema = await toPromise(
@@ -152,5 +157,5 @@ export async function fetchSchemaFromEngine(
     throw new Error("Unable to get schema from Apollo Engine");
   }
 
-  return buildIntrospectionSchemaFromSDL(engineSchema.data.service.schema);
+  return engineSchema.data.service.schema.__schema;
 }

--- a/packages/apollo/src/load-schema.ts
+++ b/packages/apollo/src/load-schema.ts
@@ -2,19 +2,32 @@ import { IntrospectionSchema } from "graphql";
 import { ApolloConfig, SchemaDependency } from "./config";
 import { fetchSchema, fetchSchemaFromEngine } from "./fetch-schema";
 
-export async function loadSchema(
-  dependency: SchemaDependency,
-  config: ApolloConfig
-): Promise<IntrospectionSchema | undefined> {
+export async function loadSchema({
+  dependency,
+  config,
+  tag
+}: {
+  dependency: SchemaDependency;
+  config: ApolloConfig;
+  tag?: string;
+}): Promise<IntrospectionSchema | undefined> {
+  if (tag && dependency.engineKey) {
+    return await fetchSchemaFromEngine({
+      apiKey: dependency.engineKey,
+      tag,
+      customEngine: config.engineEndpoint
+    });
+  }
+
   if (dependency.schema) {
     return await fetchSchema({ url: dependency.schema }, config.projectFolder);
   } else if (dependency.endpoint && dependency.endpoint.url) {
     return await fetchSchema(dependency.endpoint, config.projectFolder);
   } else if (dependency.engineKey) {
-    return await fetchSchemaFromEngine(
-      dependency.engineKey,
-      config.engineEndpoint
-    );
+    return await fetchSchemaFromEngine({
+      apiKey: dependency.engineKey,
+      customEngine: config.engineEndpoint
+    });
   } else {
     return undefined;
   }


### PR DESCRIPTION
This PR:
* adds functionality to the VSCode extension for switching to / developing against different schema tags.
* adds the ability to publish a schema to engine with a tag via the CLI and the `--tag` flag.

For context:
Schemas can be "branched" in a similar way that one might make a branch in a git repo. This concept allows developers to publish different "branches" (tags) of a schema to engine. Publishing a new tag to engine makes the new introspection available to a client, in this case, VSCode.

The result here is that an extension user can switch tags on the fly and expect all the benefits that an introspection provides: autocomplete, syntax errors, and other relevant information _specific to that tag_.

![oct-18-2018 15-47-34](https://user-images.githubusercontent.com/29644393/47188504-2e429e00-d2ed-11e8-9464-6f5f3cfd4cea.gif)

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->