### PR TITLE
Support using the proxy for Apollo iOS downloads

### DIFF
--- a/cdn/src/legacy-cli.test.ts
+++ b/cdn/src/legacy-cli.test.ts
@@ -1,0 +1,81 @@
+import { mockGlobal } from './mock'
+import fetchMock from 'fetch-mock'
+jest.mock('./sentry')
+
+const GITHUB_RELEASE =
+  "https://github.com/apollographql/apollo-tooling/releases";
+beforeEach(() => {
+    mockGlobal()
+    jest.resetModules();
+});
+
+afterEach(fetchMock.resetBehavior)
+
+it('pulls from a version if passed', async () => {
+    fetchMock.get(`${GITHUB_RELEASE}/download/apollo@0.0.1/apollo-v0.0.1-darwin-x64.tar.gz`, {
+        body: 'binary file'
+    })
+
+    require('./index');
+    const request = new Request('/legacy-cli/darwin/0.0.1');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(200);
+    expect(await response.text()).toEqual('binary file')
+})
+
+it('returns a 500 if no version is passed', async () => {
+    require('./index');
+    const { log } = require('./sentry')
+
+    const request = new Request('/legacy-cli/darwin');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(500);
+    expect(log).toHaveBeenCalled()
+    expect(await response.text()).toContain(`the darwin platform and requires a specific version`)
+})
+
+it('returns a 500 if no platform is passed', async () => {
+    require('./index');
+    const { log } = require('./sentry')
+
+    const request = new Request('/legacy-cli');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(500);
+    expect(log).toHaveBeenCalled()
+    expect(await response.text()).toContain(`the darwin platform and requires a specific version`)
+})
+
+it('returns a 500 if not asking for darwin builds', async () => {
+    require('./index');
+    const { log } = require('./sentry')
+
+    const request = new Request('/legacy-cli/linux/1.0.0');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(500);
+    expect(log).toHaveBeenCalled()
+    expect(await response.text()).toContain(`Installing the legacy CLI for usage outside of the Apollo iOS isn't supported.`)
+})
+
+it('returns a 500 if GitHub is down', async () => {
+    fetchMock.get(`${GITHUB_RELEASE}/download/apollo@0.0.1/apollo-v0.0.1-darwin-x64.tar.gz`, 500)
+    require('./index');
+    const { log } = require('./sentry')
+
+    const request = new Request('/legacy-cli/darwin/0.0.1');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(500);
+    expect(log).toHaveBeenCalled()
+    expect(await response.text()).toContain(`Error when loading legacy CLI`)
+})
+
+it('returns a 500 if asking for a bad version', async () => {
+    fetchMock.get(`${GITHUB_RELEASE}/download/apollo@0.0.1/apollo-v0.0.1-darwin-x64.tar.gz`, 404)
+    require('./index');
+    const { log } = require('./sentry')
+
+    const request = new Request('/legacy-cli/darwin/0.0.1');
+    const response: any = await self.trigger('fetch', request);
+    expect(response.status).toEqual(500);
+    expect(log).toHaveBeenCalled()
+    expect(await response.text()).toContain(`Couldn't find release for version 0.0.1 on darwin`)
+})

--- a/cdn/src/legacy-cli.ts
+++ b/cdn/src/legacy-cli.ts
@@ -1,0 +1,33 @@
+const GITHUB_RELEASE =
+  "https://github.com/apollographql/apollo-tooling/releases";
+
+type LegacyCLIArgs = {
+  platform: "darwin";
+  version: string;
+};
+
+export async function handleLegacyCLI(
+  { platform, version }: LegacyCLIArgs,
+  event: FetchEvent
+): Promise<Response> {
+  const { method, body } = event.request;
+  // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
+  const response = await fetch(
+    `${GITHUB_RELEASE}/download/apollo@${version}/apollo-v${version}-darwin-x64.tar.gz`,
+    { method, body }
+  );
+
+  if (response.ok) {
+    return response;
+  }
+
+  if (response.status === 404) {
+    throw new Error(
+      `Couldn't find release for version ${version} on ${platform}`
+    );
+  }
+
+  throw new Error(
+    `Error when loading legacy CLI for ${version} on ${platform}. Error was ${response.statusText}`
+  );
+}


### PR DESCRIPTION
This commit introduces a new path (`legacy-cli`) which functions to proxy requests for the Apollo iOS codegeneration tooling. It __only__ supports this use case since we want people using npm for normal CLI installation of the current CLI