### PR TITLE
don't error / log to sentry on unsupported methods

### DIFF
--- a/cdn/src/handler.ts
+++ b/cdn/src/handler.ts
@@ -19,8 +19,15 @@ type CLIArgs = {
 
 type PossiblePaths = [undefined, Product?, CLIArgs["platform"]?, string?];
 
+const SUPPORTED_METHODS = ["GET", "HEAD"]
 export async function handleRequest(event: FetchEvent): Promise<Response> {
   try {
+    if (!SUPPORTED_METHODS.includes(event.request.method)) {
+      return Promise.resolve(
+        new Response(`This proxy only supports the following request types: ${SUPPORTED_METHODS.join(", ")}`, { status: 500 })
+      )
+    }
+
     const url = new URL(event.request.url);
     const [, product, platform, version] = url.pathname.split(
       "/",

--- a/cdn/src/handler.ts
+++ b/cdn/src/handler.ts
@@ -23,9 +23,7 @@ const SUPPORTED_METHODS = ["GET", "HEAD"]
 export async function handleRequest(event: FetchEvent): Promise<Response> {
   try {
     if (!SUPPORTED_METHODS.includes(event.request.method)) {
-      return Promise.resolve(
-        new Response(`This proxy only supports the following request types: ${SUPPORTED_METHODS.join(", ")}`, { status: 500 })
-      )
+      return new Response(`This proxy only supports the following request types: ${SUPPORTED_METHODS.join(", ")}`, { status: 500 })
     }
 
     const url = new URL(event.request.url);
@@ -69,9 +67,7 @@ export async function handleRequest(event: FetchEvent): Promise<Response> {
     }
   } catch (e) {
     event.waitUntil(log(e, event.request));
-    return Promise.resolve(
-      new Response(e.message || e.toString(), { status: 500 })
-    );
+    return new Response(e.message || e.toString(), { status: 500 })
   }
 }
 

--- a/cdn/src/worker.test.ts
+++ b/cdn/src/worker.test.ts
@@ -114,4 +114,24 @@ it('logs internal server error and calls sentry on unexpected issue', async () =
     expect(log).toBeCalledWith(new Error(':ohno:'), request)
     expect(response.status).toEqual(500);
     expect(await response.text()).toEqual('Internal Server Error')
+    // workers give a delayed response to we need to delay resetting this mock
+    await new Promise((r) => {
+        setTimeout(() => {
+            jest.unmock('./handler')
+            r()
+        }, 5)
+        
+    })
+})
+
+it('returns an 500 if requested with a POST request', async () => {
+    const { log } = require('./sentry')
+    log.mockClear()
+    require('./index');
+
+    const request = new Request('/', { method: "POST" });
+    const response: any = await self.trigger('fetch', request);
+    expect(log).not.toHaveBeenCalled()
+    expect(response.status).toEqual(500);
+    expect(await response.text()).toContain('This proxy only supports the following request types:')
 })


### PR DESCRIPTION
This limits the worker to supporting `HEAD` (for caching) and `GET` requests when people use the CLI installer