### PR TITLE
Move installation to $HOME/.apollo/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2020-05-11
+### Added
+- Added hidden `print` command for printing out GraphQL Documents when debugging
+- Added new logger and error handling internally:
+
+Setting the `APOLLO_LOG_LEVEL` env variable controls what levels of messages are printed. For example, `APOLLO_LOG_LEVEL=warn` will only print messages with precedence of `warn` or higher. There are 5 levels of messages: `error`, `warn`, `info`, `debug`, and `trace`, where `error` has the highest precedence and `trace` has the lowest. If you want to see `trace` messages, you must use the env variable, since traces are expected to be extremely loud.
+
+The env variable can also be used to filter messages by module. For example, if you only wanted print messages from the `commands::login` module of a `info` or higher precedence, you could set the `APOLLO_LOG_LEVEL=apollo_cli::commands::login=info`.
+
+**`--verbose` and `--quiet`**
+
+There are two flags that are used to control log levels, `--verbose` and `--quiet`, and they can be used with any command. `--verbose` prints messages with a `verbose` or higher precedence (ignoring `trace` level messages). `--quiet` only prints `error` messages (since they are breaking errors and no usable output is expected).
+
+Flags will take precedence over any `APOLLO_LOG_LEVEL` env variable, and trying to use both at the same time will result in a warning.
+
+### Breaking
+- moved installation from /usr/local/bin to ~/.apollo/bin with setup of profile
+
 ## [0.0.2] - 2020-04-23
 ### Added
 - Setup new basic structure for commands including unimplemented `login` command

--- a/cdn/public/404.html
+++ b/cdn/public/404.html
@@ -147,7 +147,7 @@
         You most likely hit this page while trying to install the
         <strong>Apollo CLI</strong>. To install the latest version, copy the command below and run it in your terminal:
       </p>
-      <pre><code>curl -sSL <script language="JavaScript" type="text/javascript">document.write(window.location.href);</script> | sh</code></pre>
+      <pre><code>curl -sSL https://install.apollographql.com | sh</code></pre>
     </div>
   </body>
 </html>

--- a/cdn/public/install.sh
+++ b/cdn/public/install.sh
@@ -5,8 +5,9 @@
 set -o errexit
 
 # GitHub's URL for the latest release, will redirect.
-DESTDIR="${DESTDIR:-/usr/local/bin}"
-INSTALL_PATH="${DESTDIR}/ap"
+DESTDIR="${DESTDIR:-$HOME}"
+BIN_PATH="${DESTDIR}/.apollo/bin"
+INSTALL_PATH="${BIN_PATH}/ap"
 
 error_exit() {
   echo "$1" 1>&2
@@ -61,13 +62,17 @@ download_and_install() {
     return 1
   fi
 
-  mv ap "$DESTDIR"
+  mkdir -p "$BIN_PATH"
+
+  mv ap "$BIN_PATH"
   chmod +x "$INSTALL_PATH"
 
-  command -v ap
-
+  "$INSTALL_PATH" setup
+  
+  echo "Installed Apollo CLI in $INSTALL_PATH"
   return
 }
+
 
 download_from_proxy() {
   RELEASE_URL="https://install.apollographql.com/cli/${OS}/${VERSION}"

--- a/cdn/src/worker.test.ts
+++ b/cdn/src/worker.test.ts
@@ -54,7 +54,7 @@ it('pulls from the latest tag in GitHub if no version is passed', async () => {
         redirectUrl: "https://github.com/apollographql/apollo-cli/releases/tag/v0.0.1"
     })
 
-    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz`, {
+    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-linux.tar.gz`, {
         body: 'binary file'
     })
 
@@ -66,7 +66,7 @@ it('pulls from the latest tag in GitHub if no version is passed', async () => {
 })
 
 it('pulls from a version if passed', async () => {
-    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz`, {
+    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-linux.tar.gz`, {
         body: 'binary file'
     })
 
@@ -90,7 +90,7 @@ it('returns a 500 if GitHub is down', async () => {
 })
 
 it('returns a 500 if asking for a bad version', async () => {
-    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz`, 404)
+    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-linux.tar.gz`, 404)
     require('./index');
     const { log } = require('./sentry')
 
@@ -102,7 +102,7 @@ it('returns a 500 if asking for a bad version', async () => {
 })
 
 it('returns a 500 and message if something went really wrong', async () => {
-    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz`, {
+    fetchMock.get(`${GITHUB_RELEASE}/download/v0.0.1/ap-v0.0.1-linux.tar.gz`, {
         status: 500,
     })
     require('./index');

--- a/cdn/test/install.bats
+++ b/cdn/test/install.bats
@@ -74,13 +74,14 @@ setup() {
   mkdir "$BINDIR"
   cd "$BINDIR"
   PATH="$DESTDIR:$PATH"
+  
   function uname() { echo "Darwin"; }
   export -f uname
 
   run download_and_install
   
   assert_success
-  assert [ -x "${DESTDIR}/ap" ]
+  assert [ -x "${DESTDIR}/.apollo/bin/ap" ]
   unstub curl
 }
 
@@ -125,7 +126,7 @@ setup() {
   stub curl \
     "-sL --retry 3 https://install.apollographql.com/cli/linux/ : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar"  \
     "-sLI -o /dev/null -w %{url_effective} https://github.com/apollographql/apollo-cli/releases/latest/ : echo https://github.com/apollographql/apollo-cli/releases/tag/v0.0.1"  \
-    "-sL --retry 3 https://github.com/apollographql/apollo-cli/releases/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar.gz"
+    "-sL --retry 3 https://github.com/apollographql/apollo-cli/releases/download/v0.0.1/ap-v0.0.1-linux.tar.gz : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar.gz"
 
   run run_main
   assert_success
@@ -139,7 +140,7 @@ setup() {
   # intentionally missing .gz to fail install
   stub curl \
     "-sL --retry 3 https://install.apollographql.com/cli/linux/ : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar"  \
-    "-sL --retry 3 https://github.com/apollographql/apollo-cli/releases/download/v0.0.1/ap-v0.0.1-x86_64-linux.tar.gz : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar.gz"
+    "-sL --retry 3 https://github.com/apollographql/apollo-cli/releases/download/v0.0.1/ap-v0.0.1-linux.tar.gz : cat $FIXTURE_ROOT/ap-v0.0.1-x86_64-linux.tar.gz"
 
   run run_main
   assert_success

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 anyhow = "1.0"
 atty = "0.2"
 console = "0.6.1"
+dirs = "2.0"
 graphql-parser = { path = "../graphql-parser" }
 log = { version = "0.4", features = ["std"] }
 env_logger = "0.7.1"
@@ -19,7 +20,11 @@ term_size = "0.3.0"
 textwrap = "0.11.0"
 thiserror = "1.0.16"
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.7"
+
 [dev-dependencies]
 assert_cmd = "0.10"
 predicates = "1"
 tempfile = "3"
+

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-cli"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Apollo <opensource@apollographql.com>"]
 edition = "2018"
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -65,6 +65,9 @@ pub enum Subcommand {
     #[structopt(name = "print", setting = AppSettings::Hidden)]
     ///  🖨   parse and pretty print schemas to stdout
     Print(commands::Print),
+    #[structopt(name = "setup", setting = AppSettings::Hidden)]
+    ///  🚜  setup the Apollo toolchain in your environment
+    Setup(commands::Setup),
 }
 
 impl Subcommand {
@@ -72,6 +75,7 @@ impl Subcommand {
         match self {
             Subcommand::Login(login) => login.run(),
             Subcommand::Print(print) => print.run(),
+            Subcommand::Setup(setup) => setup.run(),
         }
     }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod login;
 pub mod print;
+pub mod setup;
 
 pub use login::Login;
 pub use print::Print;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -6,6 +6,8 @@ pub use print::Print;
 
 use crate::errors::{ExitCode, Fallible};
 
+use crate::errors::{ExitCode, Fallible};
+
 pub trait Command {
     /// Executes the command. Returns `Ok(true)` if the process should return 0,
     /// `Ok(false)` if the process should return 1, and `Err(e)` if the process

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,8 +3,7 @@ pub mod print;
 
 pub use login::Login;
 pub use print::Print;
-
-use crate::errors::{ExitCode, Fallible};
+pub use setup::Setup;
 
 use crate::errors::{ExitCode, Fallible};
 

--- a/cli/src/commands/setup.rs
+++ b/cli/src/commands/setup.rs
@@ -1,0 +1,163 @@
+use log::info;
+use structopt::StructOpt;
+
+use crate::commands::Command;
+use crate::errors::{ExitCode, Fallible};
+use crate::style;
+
+#[derive(StructOpt)]
+pub struct Setup {}
+
+impl Command for Setup {
+    fn run(self) -> Fallible<ExitCode> {
+        os::setup_environment()?;
+
+        info!(
+            "{} Setup complete. Open a new terminal to start using the Apollo CLI!",
+            style::ROCKET
+        );
+
+        Ok(ExitCode::Success)
+    }
+}
+
+#[cfg(unix)]
+mod os {
+    use std::env;
+    use std::fs::File;
+    use std::io::{self, BufRead, BufReader, Write};
+    use std::path::Path;
+
+    use crate::errors::{ErrorDetails, Fallible};
+    use crate::layout::apollo_home_bin;
+    use log::{debug, warn};
+
+    const PROFILES: [&str; 5] = [
+        ".profile",
+        ".bash_profile",
+        ".bashrc",
+        ".zshrc",
+        ".config/fish/config.fish",
+    ];
+
+    pub fn setup_environment() -> Fallible<()> {
+        let user_home_dir = dirs::home_dir().ok_or(ErrorDetails::NoHomeEnvironmentVar)?;
+
+        debug!("Searching for profiles to update");
+        let env_profile = env::var("PROFILE");
+
+        let found_profile = PROFILES
+            .iter()
+            .chain(&env_profile.as_ref().map(String::as_str))
+            .fold(false, |prev, path| {
+                let profile = user_home_dir.join(path);
+                match read_profile_without_apollo(&profile) {
+                    Some(contents) => {
+                        debug!("Profile script found: {}", profile.display());
+
+                        let write_profile = match profile.extension() {
+                            Some(ext) if ext == "fish" => write_profile_fish,
+                            _ => write_profile_sh,
+                        };
+
+                        match write_profile(&profile, contents) {
+                            Ok(()) => {
+                                debug!("Wrote $PATH addition into {}", profile.display());
+                                true
+                            }
+                            Err(err) => {
+                                warn!(
+                                    "Found profile script, but could not modify it: {}",
+                                    profile.display()
+                                );
+                                debug!("Profile modification error: {}", err);
+                                prev
+                            }
+                        }
+                    }
+                    None => {
+                        debug!("Profile script not found: {}", profile.display());
+                        prev
+                    }
+                }
+            });
+
+        if found_profile {
+            Ok(())
+        } else {
+            Err(ErrorDetails::NoShellProfile {
+                env_profile: String::new(),
+                bin_dir: apollo_home_bin()?.to_owned(),
+            }
+            .into())
+        }
+    }
+
+    fn read_profile_without_apollo(path: &Path) -> Option<String> {
+        let file = File::open(path).ok()?;
+        let reader = BufReader::new(file);
+
+        reader
+            .lines()
+            .filter(|line_result| match line_result {
+                Ok(line) if !line.contains(".apollo/bin") => true,
+                Ok(_) => false,
+                Err(_) => true,
+            })
+            .collect::<io::Result<Vec<String>>>()
+            .map(|lines| lines.join("\n"))
+            .ok()
+    }
+
+    fn write_profile_sh(path: &Path, contents: String) -> io::Result<()> {
+        let mut file = File::create(path)?;
+        write!(
+            file,
+            "{}\nexport PATH=\"$HOME/.apollo/bin:$PATH\"\n",
+            contents,
+        )
+    }
+
+    fn write_profile_fish(path: &Path, contents: String) -> io::Result<()> {
+        let mut file = File::create(path)?;
+        write!(
+            file,
+            "{}\nset -gx PATH \"$HOME/.apollo/bin\" $PATH\n",
+            contents,
+        )
+    }
+}
+
+#[cfg(windows)]
+mod os {
+    use crate::errors::{ErrorDetails, Fallible};
+    use crate::layout::apollo_home_bin;
+    use log::debug;
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    pub fn setup_environment() -> Fallible<()> {
+        let bin_dir = apollo_home_bin()?.to_string_lossy().to_string();
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+        let env = hkcu
+            .open_subkey("Environment")
+            .map_err(|_e| ErrorDetails::ReadUserPathError)?;
+
+        let path: String = env
+            .get_value("Path")
+            .map_err(|_e| ErrorDetails::ReadUserPathError)?;
+
+        if !path.contains(&bin_dir) {
+            let (key, _disp) = hkcu
+                .create_subkey("Environment")
+                .map_err(|_e| ErrorDetails::ReadUserPathError)?;
+
+            debug!("Adding {} to Path", &bin_dir);
+            key.set_value("Path", &format!("{};{}", bin_dir, path).to_string())
+                .map_err(|_e| ErrorDetails::WriteUserPathError)?;
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/layout.rs
+++ b/cli/src/layout.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use crate::errors::{ErrorDetails, Fallible};
+
+// ~/
+//     .apollo/
+//         bin/
+//             ap
+//             apollo-language-server
+//         atlas/
+//         auth.toml
+
+pub fn apollo_home() -> Fallible<PathBuf> {
+    let home = dirs::home_dir().ok_or(ErrorDetails::NoHomeEnvironmentVar)?;
+    Ok(home.join(".apollo"))
+}
+
+pub fn apollo_home_bin() -> Fallible<PathBuf> {
+    let home = apollo_home()?;
+    Ok(home.join("bin"))
+}

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -25,6 +25,7 @@ pub fn init_logger(verbose: bool, quiet: bool, env_log_level: Result<String, Var
         };
         env_logger::builder()
             .filter_level(flag_log_level)
+            .format_level(false)
             // only show timestamps on verbose and trace levels
             // only show module path on verbose and trace levels
             .format_timestamp(None)
@@ -38,6 +39,7 @@ pub fn init_logger(verbose: bool, quiet: bool, env_log_level: Result<String, Var
         let print_module_path =
             log_level_unwrapped.contains("debug") || log_level_unwrapped.contains("trace");
         env_logger::Builder::from_env(env_filter)
+            .format_level(false)
             .format_timestamp(None)
             .format_module_path(print_module_path)
             .init()

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -1,7 +1,52 @@
-use log::LevelFilter::{Debug, Error, Info};
 use std::env::VarError;
+use std::io;
+use std::io::Write;
+use std::result::Result;
+
+use env_logger::fmt::{Color, Formatter};
+use env_logger::Builder;
+use log::LevelFilter::{Debug, Error, Info};
+use log::{Level, Record};
 
 pub const APOLLO_LOG_LEVEL: &str = "APOLLO_LOG_LEVEL";
+
+fn custom_formatter(
+    should_print_modules: bool,
+) -> impl Fn(&mut Formatter, &Record) -> io::Result<()> {
+    move |buf: &mut Formatter, record: &Record| {
+        let level = record.level();
+        let mut style = buf.style();
+        let args = record.args();
+        let module_path = record.module_path();
+
+        match level {
+            Level::Trace => {
+                style.set_color(Color::Cyan).set_intense(true);
+            },
+            Level::Debug => {
+                style.set_color(Color::Magenta);
+            },
+            Level::Warn => {
+                style.set_color(Color::Yellow);
+            },
+            Level::Error => {
+                style.set_color(Color::Red).set_bold(true);
+            }
+            _ => {}
+        };
+
+        match level {
+            Level::Info => writeln!(buf, "{}", args),
+            _ => {
+                write!(buf, "[{}", style.value(level.to_level_filter()))?;
+                if should_print_modules {
+                    write!(buf, " {}", module_path.unwrap())?;
+                }
+                writeln!(buf, "] {}", style.value(args))
+            }
+        }
+    }
+}
 
 pub fn init_logger(verbose: bool, quiet: bool, env_log_level: Result<String, VarError>) {
     // warn if someone is trying to use the flags _and_ env
@@ -23,25 +68,17 @@ pub fn init_logger(verbose: bool, quiet: bool, env_log_level: Result<String, Var
             (true, false) => Debug,
             (true, true) => unreachable!("Cannot pass verbose and quiet flags"),
         };
-        env_logger::builder()
+        Builder::new()
             .filter_level(flag_log_level)
-            .format_level(false)
-            // only show timestamps on verbose and trace levels
-            // only show module path on verbose and trace levels
-            .format_timestamp(None)
-            .format_module_path(verbose)
+            .format(custom_formatter(false))
             .init()
     } else {
         let env_filter = env_logger::Env::default().filter(APOLLO_LOG_LEVEL);
         let log_level_unwrapped = env_log_level.unwrap().to_lowercase();
-        // only show timestamps on verbose and trace levels
+
         // only show module path on verbose and trace levels
-        let print_module_path =
-            log_level_unwrapped.contains("debug") || log_level_unwrapped.contains("trace");
-        env_logger::Builder::from_env(env_filter)
-            .format_level(false)
-            .format_timestamp(None)
-            .format_module_path(print_module_path)
+        Builder::from_env(env_filter)
+            .format(custom_formatter(log_level_unwrapped.contains("trace")))
             .init()
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod errors;
+mod layout;
 mod log;
 
 use crate::log::{init_logger, APOLLO_LOG_LEVEL};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod errors;
 mod layout;
 mod log;
+mod style;
 
 use crate::log::{init_logger, APOLLO_LOG_LEVEL};
 use std::env::var;

--- a/cli/src/style.rs
+++ b/cli/src/style.rs
@@ -1,10 +1,3 @@
 use console::Emoji;
 
-pub const MAX_WIDTH: usize = 100;
-
-/// Get the width of the terminal, limited to a maximum of MAX_WIDTH
-pub fn text_width() -> Option<usize> {
-    term_size::dimensions().map(|(w, _)| w.min(MAX_WIDTH))
-}
-
 pub static ROCKET: Emoji = Emoji("🚀 ", "");

--- a/cli/src/style.rs
+++ b/cli/src/style.rs
@@ -1,6 +1,10 @@
+use console::Emoji;
+
 pub const MAX_WIDTH: usize = 100;
 
 /// Get the width of the terminal, limited to a maximum of MAX_WIDTH
 pub fn text_width() -> Option<usize> {
     term_size::dimensions().map(|(w, _)| w.min(MAX_WIDTH))
 }
+
+pub static ROCKET: Emoji = Emoji("🚀 ", "");

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -1,0 +1,250 @@
+#[cfg(unix)]
+mod unix {
+    use assert_cmd::prelude::*;
+    use predicates::prelude::*;
+    use std::env;
+    use std::fs::{set_permissions, DirBuilder, File, OpenOptions};
+    use std::io::{Read, Result, Write};
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use tempfile::tempdir;
+
+    #[test]
+    fn not_found_in_usage() {
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        cli.assert()
+            .code(0)
+            .stdout(predicate::str::contains("setup").not());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn errors_with_no_home_environment() {
+        let dir = tempdir().unwrap();
+
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        cli.arg("setup")
+            .arg("--verbose")
+            .env("HOME", dir.path())
+            .assert()
+            .code(4)
+            .stderr(predicate::str::contains(format!(
+                "edit your profile manually to add '{}' to your PATH",
+                dir.path().join(".apollo/bin").to_string_lossy().to_string()
+            )));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_setup_not_fish() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        let profile = create_profile(&dir.path().join(".profile"))?;
+        let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
+        let bashrc = create_profile(&dir.path().join(".bashrc"))?;
+        let zshrc = create_profile(&dir.path().join(".zshrc"))?;
+
+        cli.arg("setup")
+            .arg("--verbose")
+            .env("HOME", dir.path())
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("Setup complete"));
+
+        let profile_buf = read_profile(profile)?;
+        assert_eq!(true, has_apollo.eval(&profile_buf));
+
+        let bash_profile_buf = read_profile(bash_profile)?;
+        assert_eq!(true, has_apollo.eval(&bash_profile_buf));
+
+        let bashrc_buf = read_profile(bashrc)?;
+        assert_eq!(true, has_apollo.eval(&bashrc_buf));
+
+        let zshrc_buf = read_profile(zshrc)?;
+        assert_eq!(true, has_apollo.eval(&zshrc_buf));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_setup_fish() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let has_apollo = predicate::str::contains("set -gx PATH \"$HOME/.apollo/bin\" $PATH");
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        let fish_path = dir.path().join(".config/fish");
+        DirBuilder::new().recursive(true).create(&fish_path)?;
+
+        let fish = create_profile(&fish_path.join("config.fish"))?;
+
+        cli.arg("setup")
+            .arg("--verbose")
+            .env("HOME", dir.path())
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("Setup complete"));
+
+        let fish_buf = read_profile(fish)?;
+        assert_eq!(true, has_apollo.eval(&fish_buf));
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn removes_existing_apollo_paths() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        let mut profile = create_profile(&dir.path().join(".profile"))?;
+        writeln!(profile, "# .apollo/bin")?;
+
+        cli.arg("setup")
+            .arg("--verbose")
+            .env("HOME", dir.path())
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("Setup complete"));
+
+        let profile_buf = read_profile(profile)?;
+        assert_eq!(false, has_apollo.eval(&profile_buf));
+        assert_eq!(
+            false,
+            predicate::str::contains("# .apollo").eval(&profile_buf)
+        );
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_setup_custom_profile() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        let path = dir.path().join(".my_config_fmt");
+        let profile = create_profile(&path)?;
+
+        cli.arg("setup")
+            .arg("--verbose")
+            .env("HOME", dir.path())
+            .env("PROFILE", &path.to_string_lossy().to_string())
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("Setup complete"));
+
+        let profile_buf = read_profile(profile)?;
+        assert_eq!(true, has_apollo.eval(&profile_buf));
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn warns_if_cannot_write() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        let path = dir.path().join(".profile");
+        let file = create_profile(&path)?;
+        let metadata = file.metadata()?;
+        let mut permissions = metadata.permissions();
+
+        permissions.set_readonly(true);
+        set_permissions(path, permissions)?;
+
+        cli.arg("setup")
+            .env("HOME", dir.path())
+            .env("APOLLO_LOGLEVEL", "warn")
+            .assert()
+            .code(4)
+            .stderr(predicate::str::contains(
+                "Found profile script, but could not modify it:",
+            ));
+
+        Ok(())
+    }
+
+    fn create_profile(path: &PathBuf) -> Result<File> {
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true)
+            .open(path)
+    }
+
+    fn read_profile(mut file: File) -> Result<String> {
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)?;
+        Ok(buf)
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::env;
+    use std::io;
+    use std::process::Command;
+
+    use assert_cmd::prelude::*;
+    use predicates::prelude::*;
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    #[test]
+    fn not_found_in_usage() {
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        cli.assert()
+            .code(0)
+            .stdout(predicate::str::contains("setup").not());
+    }
+
+    // Since these test share a common db (the winreg) that we can't easily mock
+    // we combine the tests into a single one (so that they don't run in parallel)
+    // instead of forcing the windows test suite to be run single threaded
+    #[test]
+    fn write_path_to_registry() -> io::Result<()> {
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let (key, _disp) = hkcu.create_subkey("Environment")?;
+        let current_path: String = key.get_value("Path")?;
+        // delete the Path value in the Environment sub_key
+        key.set_value("Path", &";")?;
+
+        let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        cli.arg("setup")
+            .arg("--debug")
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("Setup complete"));
+
+        key.set_value("Path", &current_path)?;
+
+        // below is a *new* test (error_if_path_not_found())
+
+        // delete the Path value in the Environment sub_key
+        key.delete_value("Path")?;
+
+        let mut cli_two = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        cli_two
+            .arg("setup")
+            .assert()
+            .code(4)
+            .stderr(predicate::str::contains(
+                "Could not read user Path environment variable.",
+            ));
+
+        key.set_value("Path", &current_path)?;
+
+        Ok(())
+    }
+}

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -54,7 +54,7 @@ mod unix {
             .env("HOME", dir.path())
             .assert()
             .code(0)
-            .stdout(predicate::str::contains("Setup complete"));
+            .stderr(predicate::str::contains("Setup complete"));
 
         let profile_buf = read_profile(profile)?;
         assert_eq!(true, has_apollo.eval(&profile_buf));
@@ -87,7 +87,7 @@ mod unix {
             .env("HOME", dir.path())
             .assert()
             .code(0)
-            .stdout(predicate::str::contains("Setup complete"));
+            .stderr(predicate::str::contains("Setup complete"));
 
         let fish_buf = read_profile(fish)?;
         assert_eq!(true, has_apollo.eval(&fish_buf));
@@ -106,11 +106,10 @@ mod unix {
         writeln!(profile, "# .apollo/bin")?;
 
         cli.arg("setup")
-            .arg("--verbose")
             .env("HOME", dir.path())
             .assert()
             .code(0)
-            .stdout(predicate::str::contains("Setup complete"));
+            .stderr(predicate::str::contains("Setup complete"));
 
         let profile_buf = read_profile(profile)?;
         assert_eq!(false, has_apollo.eval(&profile_buf));
@@ -138,7 +137,7 @@ mod unix {
             .env("PROFILE", &path.to_string_lossy().to_string())
             .assert()
             .code(0)
-            .stdout(predicate::str::contains("Setup complete"));
+            .stderr(predicate::str::contains("Setup complete"));
 
         let profile_buf = read_profile(profile)?;
         assert_eq!(true, has_apollo.eval(&profile_buf));
@@ -162,7 +161,7 @@ mod unix {
 
         cli.arg("setup")
             .env("HOME", dir.path())
-            .env("APOLLO_LOGLEVEL", "warn")
+            .env("APOLLO_LOG_LEVEL", "warn")
             .assert()
             .code(4)
             .stderr(predicate::str::contains(

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -223,7 +223,7 @@ mod windows {
             .arg("--debug")
             .assert()
             .code(0)
-            .stdout(predicate::str::contains("Setup complete"));
+            .stderr(predicate::str::contains("Setup complete"));
 
         key.set_value("Path", &current_path)?;
 


### PR DESCRIPTION
This PR changes the install location of the CLI to be $HOME/.apollo/bin and provides a setup command for windows and unix environments to allow for that path to be added to the $PATH of their profile