### PR TITLE
setup error hooks for unexpected panics

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "apollo-cli"
 version = "0.0.3"
 authors = ["Apollo <opensource@apollographql.com>"]
+homepage = "https://github.com/apollographql/apollo-cli"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,9 +12,10 @@ anyhow = "1.0"
 atty = "0.2"
 console = "0.6.1"
 dirs = "2.0"
-graphql-parser = { path = "../graphql-parser" }
-log = { version = "0.4", features = ["std"] }
 env_logger = "0.7.1"
+graphql-parser = { path = "../graphql-parser" }
+human-panic = "1.0.3"
+log = { version = "0.4", features = ["std"] }
 serde = "1.0"
 structopt = "*"
 term_size = "0.3.0"


### PR DESCRIPTION
One of the biggest mistakes of the last CLI was not making it very clear when there was a user error vs a CLI error (panic/throw). The new CLI already has a special output for errors but this PR introduces a panic handler using [human panic](https://crates.io/crates/human-panic)