### PR TITLE
Embed queries and fragments within the schema grammar.

### DIFF
--- a/graphql-parser/src/query/ast.rs
+++ b/graphql-parser/src/query/ast.rs
@@ -42,6 +42,7 @@ pub enum Definition<'a, T: Text<'a>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FragmentDefinition<'a, T: Text<'a>> {
     pub position: Pos,
+    pub description: Option<String>,
     pub name: T::Value,
     pub type_condition: TypeCondition<'a, T>,
     pub directives: Vec<Directive<'a, T>>,
@@ -59,6 +60,7 @@ pub enum OperationDefinition<'a, T: Text<'a>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Query<'a, T: Text<'a>> {
     pub position: Pos,
+    pub description: Option<String>,
     pub name: Option<T::Value>,
     pub variable_definitions: Vec<VariableDefinition<'a, T>>,
     pub directives: Vec<Directive<'a, T>>,
@@ -68,6 +70,7 @@ pub struct Query<'a, T: Text<'a>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Mutation<'a, T: Text<'a>> {
     pub position: Pos,
+    pub description: Option<String>,
     pub name: Option<T::Value>,
     pub variable_definitions: Vec<VariableDefinition<'a, T>>,
     pub directives: Vec<Directive<'a, T>>,
@@ -77,6 +80,7 @@ pub struct Mutation<'a, T: Text<'a>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Subscription<'a, T: Text<'a>> {
     pub position: Pos,
+    pub description: Option<String>,
     pub name: Option<T::Value>,
     pub variable_definitions: Vec<VariableDefinition<'a, T>>,
     pub directives: Vec<Directive<'a, T>>,

--- a/graphql-parser/src/query/grammar.rs
+++ b/graphql-parser/src/query/grammar.rs
@@ -71,7 +71,10 @@ pub fn selection_set<'a, S>(input: &mut TokenStream<'a>)
         position().skip(punct("{")),
         many1(parser(selection)),
         position().skip(punct("}")),
-    ).map(|(start, items, end)| SelectionSet { span: (start, end), items })
+    ).map(|(start, items, end)| SelectionSet {
+        span: (start, end),
+        items
+    })
     .parse_stream(input)
 }
 
@@ -84,7 +87,7 @@ pub fn query<'a, T: Text<'a>>(input: &mut TokenStream<'a>)
     .and(parser(operation_common))
     .map(|(position, (name, variable_definitions, directives, selection_set))|
         Query {
-            position, name, selection_set, variable_definitions, directives,
+            position, description: None, name, selection_set, variable_definitions, directives,
         })
     .parse_stream(input)
 }
@@ -135,7 +138,7 @@ pub fn mutation<'a, T: Text<'a>>(input: &mut TokenStream<'a>)
     .and(parser(operation_common))
     .map(|(position, (name, variable_definitions, directives, selection_set))|
         Mutation {
-            position, name, selection_set, variable_definitions, directives,
+            position, description: None, name, selection_set, variable_definitions, directives,
         })
     .parse_stream(input)
 }
@@ -149,7 +152,7 @@ pub fn subscription<'a, T: Text<'a>>(input: &mut TokenStream<'a>)
     .and(parser(operation_common))
     .map(|(position, (name, variable_definitions, directives, selection_set))|
         Subscription {
-            position, name, selection_set, variable_definitions, directives,
+            position, description: None, name, selection_set, variable_definitions, directives,
         })
     .parse_stream(input)
 }
@@ -177,7 +180,7 @@ pub fn fragment_definition<'a, T: Text<'a>>(input: &mut TokenStream<'a>)
         parser(selection_set)
     ).map(|(position, name, type_condition, directives, selection_set)| {
         FragmentDefinition {
-            position, name, type_condition, directives, selection_set,
+            position, description: None, name, type_condition, directives, selection_set,
         }
     })
     .parse_stream(input)

--- a/graphql-parser/src/query/mod.rs
+++ b/graphql-parser/src/query/mod.rs
@@ -6,6 +6,10 @@ mod format;
 mod grammar;
 
 
-pub use self::grammar::parse_query;
+pub use self::grammar::{
+  parse_query,
+  operation_definition,
+  fragment_definition,
+};
 pub use self::error::ParseError;
 pub use self::ast::*;

--- a/graphql-parser/src/schema/ast.rs
+++ b/graphql-parser/src/schema/ast.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub use crate::common::{Directive, Type, Value, Text};
 use crate::position::Pos;
 
+pub use crate::query::{OperationDefinition, FragmentDefinition};
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Document<'a, T: Text<'a>>
     where T: Text<'a>
@@ -18,6 +20,8 @@ pub enum Definition<'a, T: Text<'a>> {
     Type(TypeDefinition<'a, T>),
     TypeExtension(TypeExtension<'a, T>),
     Directive(DirectiveDefinition<'a, T>),
+    Operation(OperationDefinition<'a, T>),
+    Fragment(FragmentDefinition<'a, T>),
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/graphql-parser/src/schema/ast.rs
+++ b/graphql-parser/src/schema/ast.rs
@@ -14,10 +14,10 @@ pub struct Document<'a, T: Text<'a>>
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Definition<'a, T: Text<'a>> {
-    SchemaDefinition(SchemaDefinition<'a, T>),
-    TypeDefinition(TypeDefinition<'a, T>),
+    Schema(SchemaDefinition<'a, T>),
+    Type(TypeDefinition<'a, T>),
     TypeExtension(TypeExtension<'a, T>),
-    DirectiveDefinition(DirectiveDefinition<'a, T>),
+    Directive(DirectiveDefinition<'a, T>),
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/graphql-parser/src/schema/format.rs
+++ b/graphql-parser/src/schema/format.rs
@@ -47,12 +47,13 @@ impl<'a, T> Displayable for Definition<'a, T>
     where T: Text<'a>,
 {
     fn display(&self, f: &mut Formatter) {
-        f.margin();
         match *self {
-            Definition::Schema(ref s) => s.display(f),
-            Definition::Type(ref t) => t.display(f),
-            Definition::TypeExtension(ref e) => e.display(f),
-            Definition::Directive(ref d) => d.display(f),
+            Definition::Schema(ref s) => { f.margin(); s.display(f) },
+            Definition::Type(ref t) => { f.margin(); t.display(f) },
+            Definition::TypeExtension(ref e) => { f.margin(); e.display(f) },
+            Definition::Directive(ref d) => { f.margin(); d.display(f) },
+            Definition::Operation(ref o) => o.display(f),
+            Definition::Fragment(ref g) => g.display(f),
         }
     }
 }

--- a/graphql-parser/src/schema/format.rs
+++ b/graphql-parser/src/schema/format.rs
@@ -49,10 +49,10 @@ impl<'a, T> Displayable for Definition<'a, T>
     fn display(&self, f: &mut Formatter) {
         f.margin();
         match *self {
-            Definition::SchemaDefinition(ref s) => s.display(f),
-            Definition::TypeDefinition(ref t) => t.display(f),
+            Definition::Schema(ref s) => s.display(f),
+            Definition::Type(ref t) => t.display(f),
             Definition::TypeExtension(ref e) => e.display(f),
-            Definition::DirectiveDefinition(ref d) => d.display(f),
+            Definition::Directive(ref d) => d.display(f),
         }
     }
 }

--- a/graphql-parser/src/schema/grammar.rs
+++ b/graphql-parser/src/schema/grammar.rs
@@ -6,6 +6,7 @@ use combine::combinator::{sep_by1};
 
 use crate::tokenizer::{Kind as T, Token, TokenStream};
 use crate::helpers::{punct, ident, kind, name};
+use crate::query::{operation_definition, fragment_definition};
 use crate::common::{directives, string, default_value, parse_type, Text};
 use crate::schema::error::{ParseError};
 use crate::schema::ast::*;
@@ -503,6 +504,8 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
                 parser(enum_type).map(Enum),
                 parser(input_object_type).map(InputObject),
             )).map(Definition::Type),
+            parser(operation_definition).map(Definition::Operation),
+            parser(fragment_definition).map(Definition::Fragment),
             parser(directive_definition).map(Definition::Directive),
         ))
     )
@@ -513,6 +516,8 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
             use crate::schema::ast::TypeDefinition::*;
             use crate::schema::ast::Definition::*;
             use crate::schema::ast::Definition::{Type as T};
+            use crate::schema::ast::Definition::{Operation as Op};
+            use crate::query::OperationDefinition::*;
             match def {
                 T(Scalar(ref mut s)) => s.description = descr,
                 T(Object(ref mut o)) => o.description = descr,
@@ -521,6 +526,11 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
                 T(Enum(ref mut e)) => e.description = descr,
                 T(InputObject(ref mut o)) => o.description = descr,
                 Directive(ref mut d) => d.description = descr,
+                Op(SelectionSet(_)) => {},
+                Op(Query(ref mut op_q)) => op_q.description = descr,
+                Op(Mutation(ref mut op_m)) => op_m.description = descr,
+                Op(Subscription(ref mut op_s)) => op_s.description = descr,
+                Fragment(ref mut f) => f.description = descr,
                 Schema(_) => unreachable!(),
                 TypeExtension(_) => unreachable!(),
             }

--- a/graphql-parser/src/schema/grammar.rs
+++ b/graphql-parser/src/schema/grammar.rs
@@ -502,8 +502,8 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
                 parser(union_type).map(Union),
                 parser(enum_type).map(Enum),
                 parser(input_object_type).map(InputObject),
-            )).map(Definition::TypeDefinition),
-            parser(directive_definition).map(Definition::DirectiveDefinition),
+            )).map(Definition::Type),
+            parser(directive_definition).map(Definition::Directive),
         ))
     )
         // We can't set description inside type definition parser, because
@@ -512,7 +512,7 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
         .map(|(descr, mut def)| {
             use crate::schema::ast::TypeDefinition::*;
             use crate::schema::ast::Definition::*;
-            use crate::schema::ast::Definition::{TypeDefinition as T};
+            use crate::schema::ast::Definition::{Type as T};
             match def {
                 T(Scalar(ref mut s)) => s.description = descr,
                 T(Object(ref mut o)) => o.description = descr,
@@ -520,8 +520,8 @@ pub fn described_definition<'a, T>(input: &mut TokenStream<'a>)
                 T(Union(ref mut u)) => u.description = descr,
                 T(Enum(ref mut e)) => e.description = descr,
                 T(InputObject(ref mut o)) => o.description = descr,
-                DirectiveDefinition(ref mut d) => d.description = descr,
-                SchemaDefinition(_) => unreachable!(),
+                Directive(ref mut d) => d.description = descr,
+                Schema(_) => unreachable!(),
                 TypeExtension(_) => unreachable!(),
             }
             def
@@ -551,7 +551,7 @@ pub fn definition<'a, T>(input: &mut TokenStream<'a>)
     where T: Text<'a>,
 {
     choice((
-        parser(schema).map(Definition::SchemaDefinition),
+        parser(schema).map(Definition::Schema),
         parser(type_extension).map(Definition::TypeExtension),
         parser(described_definition),
     )).parse_stream(input)
@@ -586,7 +586,7 @@ mod test {
     fn one_field() {
         assert_eq!(ast("schema { query: Query }"), Document {
             definitions: vec![
-                Definition::SchemaDefinition(
+                Definition::Schema(
                     SchemaDefinition {
                         position: Pos { line: 1, column: 1 },
                         directives: vec![],

--- a/graphql-parser/tests/schema_kitchen_sink.canonical.graphql
+++ b/graphql-parser/tests/schema_kitchen_sink.canonical.graphql
@@ -104,3 +104,20 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+fragment SomeNamedFragment on SomeType {
+  fieldOne
+  aliased: fieldTwo {
+    some {
+      deep
+    }
+  }
+  yetAnother @withADirective(param: 3, enumParam: VALUE)
+}
+
+query StoredQuery($param: InputType, $other: ScalarType) {
+  lookup {
+    various
+    things
+  }
+}

--- a/graphql-parser/tests/schema_kitchen_sink.graphql
+++ b/graphql-parser/tests/schema_kitchen_sink.graphql
@@ -115,3 +115,17 @@ directive @include2(if: Boolean!) on
   | FIELD
   | FRAGMENT_SPREAD
   | INLINE_FRAGMENT
+
+fragment SomeNamedFragment on SomeType {
+  fieldOne
+  aliased: fieldTwo {
+    some { deep }
+  }
+  yetAnother @withADirective(param: 3, enumParam: VALUE)
+}
+
+query StoredQuery($param: InputType, $other: ScalarType) {
+  lookup {
+    various things  
+  }
+}

--- a/graphql-parser/tests/snapshots/tests__parse_query__directive_args__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__directive_args__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__directive_args__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__directive_args__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__fragment__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__fragment__unix.snap
@@ -8,6 +8,7 @@ Ok(
             Fragment(
                 FragmentDefinition {
                     position: Pos(1:1),
+                    description: None,
                     name: "frag",
                     type_condition: On(
                         "Friend",

--- a/graphql-parser/tests/snapshots/tests__parse_query__fragment__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__fragment__win.snap
@@ -8,6 +8,7 @@ Ok(
             Fragment(
                 FragmentDefinition {
                     position: Pos(1:1),
+                    description: None,
                     name: "frag",
                     type_condition: On(
                         "Friend",

--- a/graphql-parser/tests/snapshots/tests__parse_query__fragment_spread__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__fragment_spread__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__fragment_spread__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__fragment_spread__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment_dir__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment_dir__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment_dir__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__inline_fragment_dir__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__minimal_mutation__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__minimal_mutation__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__minimal_mutation__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__minimal_mutation__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__minimal_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__minimal_query__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__minimal_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__minimal_query__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__mutation_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__mutation_directive__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__mutation_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__mutation_directive__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__named_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__named_query__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__named_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__named_query__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__nested_selection__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__nested_selection__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__nested_selection__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__nested_selection__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_aliases__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_aliases__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_aliases__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_aliases__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_arguments__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_arguments__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_arguments__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_arguments__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_directive__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_directive__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_kitchen_sink__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_kitchen_sink__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(6:1),
+                        description: None,
                         name: Some(
                             "queryName",
                         ),
@@ -306,6 +307,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(27:1),
+                        description: None,
                         name: Some(
                             "likeStory",
                         ),
@@ -391,6 +393,7 @@ Ok(
                 Subscription(
                     Subscription {
                         position: Pos(35:1),
+                        description: None,
                         name: Some(
                             "StoryLikeSubscription",
                         ),
@@ -526,6 +529,7 @@ Ok(
             Fragment(
                 FragmentDefinition {
                     position: Pos(48:1),
+                    description: None,
                     name: "frag",
                     type_condition: On(
                         "Friend",

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_kitchen_sink__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_kitchen_sink__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(10:1),
+                        description: None,
                         name: Some(
                             "queryName",
                         ),
@@ -306,6 +307,7 @@ Ok(
                 Mutation(
                     Mutation {
                         position: Pos(31:1),
+                        description: None,
                         name: Some(
                             "likeStory",
                         ),
@@ -391,6 +393,7 @@ Ok(
                 Subscription(
                     Subscription {
                         position: Pos(39:1),
+                        description: None,
                         name: Some(
                             "StoryLikeSubscription",
                         ),
@@ -526,6 +529,7 @@ Ok(
             Fragment(
                 FragmentDefinition {
                     position: Pos(52:1),
+                    description: None,
                     name: "frag",
                     type_condition: On(
                         "Friend",

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_list_argument__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_list_argument__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_list_argument__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_list_argument__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_object_argument__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_object_argument__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_object_argument__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_object_argument__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_float__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_float__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_float__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_float__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_list__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_list__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_list__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_list__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_object__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_object__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_object__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_object__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_string__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_string__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_string__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_default_string__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_defaults__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_defaults__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_var_defaults__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_var_defaults__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_vars__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_vars__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__query_vars__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__query_vars__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: Some(
                             "Foo",
                         ),

--- a/graphql-parser/tests/snapshots/tests__parse_query__string_literal__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__string_literal__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__string_literal__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__string_literal__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__subscription_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__subscription_directive__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Subscription(
                     Subscription {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__subscription_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__subscription_directive__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Subscription(
                     Subscription {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [

--- a/graphql-parser/tests/snapshots/tests__parse_query__triple_quoted_literal__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__triple_quoted_literal__unix.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_query__triple_quoted_literal__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_query__triple_quoted_literal__win.snap
@@ -9,6 +9,7 @@ Ok(
                 Query(
                     Query {
                         position: Pos(1:1),
+                        description: None,
                         name: None,
                         variable_definitions: [],
                         directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(1:1),
                     description: None,

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(1:1),
                     description: None,

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive_args__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive_args__unix.snap
@@ -2,8 +2,81 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [
+                                            Directive {
+                                                position: Pos(2:8),
+                                                name: "dir",
+                                                arguments: [
+                                                    (
+                                                        "a",
+                                                        Int(
+                                                            Number(
+                                                                1,
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "b",
+                                                        String(
+                                                            "2",
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "c",
+                                                        Boolean(
+                                                            true,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "d",
+                                                        Boolean(
+                                                            false,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "e",
+                                                        Null,
+                                                    ),
+                                                ],
+                                            },
+                                        ],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive_args__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive_args__win.snap
@@ -2,8 +2,81 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [
+                                            Directive {
+                                                position: Pos(2:8),
+                                                name: "dir",
+                                                arguments: [
+                                                    (
+                                                        "a",
+                                                        Int(
+                                                            Number(
+                                                                1,
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "b",
+                                                        String(
+                                                            "2",
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "c",
+                                                        Boolean(
+                                                            true,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "d",
+                                                        Boolean(
+                                                            false,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        "e",
+                                                        Null,
+                                                    ),
+                                                ],
+                                            },
+                                        ],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive_descriptions__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive_descriptions__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(4:1),
                     description: Some(
@@ -35,7 +35,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(14:1),
                     description: Some(

--- a/graphql-parser/tests/snapshots/tests__parse_schema__directive_descriptions__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__directive_descriptions__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(4:1),
                     description: Some(
@@ -35,7 +35,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(14:1),
                     description: Some(

--- a/graphql-parser/tests/snapshots/tests__parse_schema__empty_union__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__empty_union__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__empty_union__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__empty_union__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__enums__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__enums__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__enums__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__enums__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_bad_args__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_bad_args__unix.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 2:10\nUnexpected `[[Punctuator]`\nExpected `Name`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_bad_args__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_bad_args__win.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 2:10\nUnexpected `[[Punctuator]`\nExpected `Name`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_onion__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_onion__unix.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `onion[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 1:1\nUnexpected `onion[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input`, `{`, `query`, `mutation`, `subscription`, `fragment` or `directive`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_onion__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_onion__win.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `onion[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 1:1\nUnexpected `onion[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input`, `{`, `query`, `mutation`, `subscription`, `fragment` or `directive`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_querry__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_querry__unix.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `querry[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 1:1\nUnexpected `querry[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input`, `{`, `query`, `mutation`, `subscription`, `fragment` or `directive`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fail_querry__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fail_querry__win.snap
@@ -4,6 +4,6 @@ expression: result
 ---
 Err(
     ParseError(
-        "Parse error at 1:1\nUnexpected `querry[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
+        "Parse error at 1:1\nUnexpected `querry[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input`, `{`, `query`, `mutation`, `subscription`, `fragment` or `directive`\n",
     ),
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fragment__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fragment__unix.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `fragment[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(1:1),
+                    description: None,
+                    name: "frag",
+                    type_condition: On(
+                        "Friend",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(1:25),
+                            Pos(3:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(2:3),
+                                    alias: None,
+                                    name: "node",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(2:3),
+                                            Pos(2:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fragment__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fragment__win.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `fragment[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(1:1),
+                    description: None,
+                    name: "frag",
+                    type_condition: On(
+                        "Friend",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(1:25),
+                            Pos(3:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(2:3),
+                                    alias: None,
+                                    name: "node",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(2:3),
+                                            Pos(2:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fragment_spread__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fragment_spread__unix.snap
@@ -2,8 +2,68 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(6:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(5:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                FragmentSpread(
+                                                    FragmentSpread {
+                                                        position: Pos(4:8),
+                                                        fragment_name: "something",
+                                                        directives: [],
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__fragment_spread__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__fragment_spread__win.snap
@@ -2,8 +2,68 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(6:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(5:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                FragmentSpread(
+                                                    FragmentSpread {
+                                                        position: Pos(4:8),
+                                                        fragment_name: "something",
+                                                        directives: [],
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__implements__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__implements__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),
@@ -19,7 +19,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(3:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__implements__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__implements__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),
@@ -19,7 +19,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(3:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__implements_amp__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__implements_amp__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),
@@ -20,7 +20,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(2:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__implements_amp__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__implements_amp__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),
@@ -20,7 +20,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(2:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment__unix.snap
@@ -2,8 +2,96 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(8:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(7:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(4:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(4:17),
+                                                                Pos(6:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(5:7),
+                                                                        alias: None,
+                                                                        name: "name",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(5:7),
+                                                                                Pos(5:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment__win.snap
@@ -2,8 +2,96 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(8:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(7:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(4:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(4:17),
+                                                                Pos(6:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(5:7),
+                                                                        alias: None,
+                                                                        name: "name",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(5:7),
+                                                                                Pos(5:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment_dir__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment_dir__unix.snap
@@ -2,8 +2,102 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(8:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(7:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(4:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(4:17),
+                                                                name: "defer",
+                                                                arguments: [],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(4:24),
+                                                                Pos(6:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(5:7),
+                                                                        alias: None,
+                                                                        name: "name",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(5:7),
+                                                                                Pos(5:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment_dir__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__inline_fragment_dir__win.snap
@@ -2,8 +2,102 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(8:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(7:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(4:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(4:17),
+                                                                name: "defer",
+                                                                arguments: [],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(4:24),
+                                                                Pos(6:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(5:7),
+                                                                        alias: None,
+                                                                        name: "name",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(5:7),
+                                                                                Pos(5:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__input_type__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__input_type__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__input_type__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__input_type__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__interface__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__interface__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__interface__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__interface__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_mutation__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_mutation__unix.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `mutation[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:10),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "notify",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_mutation__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_mutation__win.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `mutation[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:10),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "notify",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_query__unix.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_query__win.snap
@@ -2,8 +2,44 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_schema__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_schema__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            SchemaDefinition(
+            Schema(
                 SchemaDefinition {
                     position: Pos(1:1),
                     directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_schema__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_schema__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            SchemaDefinition(
+            Schema(
                 SchemaDefinition {
                     position: Pos(1:1),
                     directives: [],

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_type__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_type__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__minimal_type__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__minimal_type__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__mutation_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__mutation_directive__unix.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `mutation[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:10),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:21),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__mutation_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__mutation_directive__win.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `mutation[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:10),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:21),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__named_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__named_query__unix.snap
@@ -2,8 +2,46 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:11),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__named_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__named_query__win.snap
@@ -2,8 +2,46 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:11),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__nested_selection__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__nested_selection__unix.snap
@@ -2,8 +2,61 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(5:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(4:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__nested_selection__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__nested_selection__win.snap
@@ -2,8 +2,61 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(5:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:8),
+                                                Pos(4:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(3:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(3:5),
+                                                                Pos(3:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_aliases__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_aliases__unix.snap
@@ -2,8 +2,46 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: Some(
+                                            "an_alias",
+                                        ),
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_aliases__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_aliases__win.snap
@@ -2,8 +2,46 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: Some(
+                                            "an_alias",
+                                        ),
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_arguments__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_arguments__unix.snap
@@ -2,8 +2,53 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_arguments__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_arguments__win.snap
@@ -2,8 +2,53 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_directive__unix.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:7),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:18),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_directive__win.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:7),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:18),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_kitchen_sink__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_kitchen_sink__unix.snap
@@ -2,8 +2,652 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 6:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(6:1),
+                        description: None,
+                        name: Some(
+                            "queryName",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(6:17),
+                                name: "foo",
+                                var_type: NamedType(
+                                    "ComplexType",
+                                ),
+                                default_value: None,
+                            },
+                            VariableDefinition {
+                                position: Pos(6:36),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Enum(
+                                        "MOBILE",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(6:58),
+                                Pos(25:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(7:3),
+                                        alias: Some(
+                                            "whoever123is",
+                                        ),
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                List(
+                                                    [
+                                                        Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(7:38),
+                                                Pos(24:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(8:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(8:5),
+                                                                Pos(8:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(9:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(9:17),
+                                                                name: "defer",
+                                                                arguments: [],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(9:24),
+                                                                Pos(17:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(10:7),
+                                                                        alias: None,
+                                                                        name: "field2",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(10:14),
+                                                                                Pos(16:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(11:9),
+                                                                                        alias: None,
+                                                                                        name: "id",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(11:9),
+                                                                                                Pos(11:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(12:9),
+                                                                                        alias: Some(
+                                                                                            "alias",
+                                                                                        ),
+                                                                                        name: "field1",
+                                                                                        arguments: [
+                                                                                            (
+                                                                                                "first",
+                                                                                                Int(
+                                                                                                    Number(
+                                                                                                        10,
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            (
+                                                                                                "after",
+                                                                                                Variable(
+                                                                                                    "foo",
+                                                                                                ),
+                                                                                            ),
+                                                                                        ],
+                                                                                        directives: [
+                                                                                            Directive {
+                                                                                                position: Pos(12:46),
+                                                                                                name: "include",
+                                                                                                arguments: [
+                                                                                                    (
+                                                                                                        "if",
+                                                                                                        Variable(
+                                                                                                            "foo",
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ],
+                                                                                            },
+                                                                                        ],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(12:65),
+                                                                                                Pos(15:9),
+                                                                                            ),
+                                                                                            items: [
+                                                                                                Field(
+                                                                                                    Field {
+                                                                                                        position: Pos(13:11),
+                                                                                                        alias: None,
+                                                                                                        name: "id",
+                                                                                                        arguments: [],
+                                                                                                        directives: [],
+                                                                                                        selection_set: SelectionSet {
+                                                                                                            span: (
+                                                                                                                Pos(13:11),
+                                                                                                                Pos(13:11),
+                                                                                                            ),
+                                                                                                            items: [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                FragmentSpread(
+                                                                                                    FragmentSpread {
+                                                                                                        position: Pos(14:14),
+                                                                                                        fragment_name: "frag",
+                                                                                                        directives: [],
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(18:9),
+                                                        type_condition: None,
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(18:9),
+                                                                name: "skip",
+                                                                arguments: [
+                                                                    (
+                                                                        "unless",
+                                                                        Variable(
+                                                                            "foo",
+                                                                        ),
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(18:29),
+                                                                Pos(20:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(19:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(19:7),
+                                                                                Pos(19:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(21:9),
+                                                        type_condition: None,
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(21:9),
+                                                                Pos(23:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(22:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(22:7),
+                                                                                Pos(22:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(27:1),
+                        description: None,
+                        name: Some(
+                            "likeStory",
+                        ),
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(27:20),
+                                Pos(33:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(28:3),
+                                        alias: None,
+                                        name: "like",
+                                        arguments: [
+                                            (
+                                                "story",
+                                                Int(
+                                                    Number(
+                                                        123,
+                                                    ),
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [
+                                            Directive {
+                                                position: Pos(28:20),
+                                                name: "defer",
+                                                arguments: [],
+                                            },
+                                        ],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(28:27),
+                                                Pos(32:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(29:5),
+                                                        alias: None,
+                                                        name: "story",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(29:11),
+                                                                Pos(31:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(30:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(30:7),
+                                                                                Pos(30:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Operation(
+                Subscription(
+                    Subscription {
+                        position: Pos(35:1),
+                        description: None,
+                        name: Some(
+                            "StoryLikeSubscription",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(35:36),
+                                name: "input",
+                                var_type: NamedType(
+                                    "StoryLikeSubscribeInput",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(35:69),
+                                Pos(46:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(36:3),
+                                        alias: None,
+                                        name: "storyLikeSubscribe",
+                                        arguments: [
+                                            (
+                                                "input",
+                                                Variable(
+                                                    "input",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(36:37),
+                                                Pos(45:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(37:5),
+                                                        alias: None,
+                                                        name: "story",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(37:11),
+                                                                Pos(44:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(38:7),
+                                                                        alias: None,
+                                                                        name: "likers",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(38:14),
+                                                                                Pos(40:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(39:9),
+                                                                                        alias: None,
+                                                                                        name: "count",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(39:9),
+                                                                                                Pos(39:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(41:7),
+                                                                        alias: None,
+                                                                        name: "likeSentence",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(41:20),
+                                                                                Pos(43:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(42:9),
+                                                                                        alias: None,
+                                                                                        name: "text",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(42:9),
+                                                                                                Pos(42:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(48:1),
+                    description: None,
+                    name: "frag",
+                    type_condition: On(
+                        "Friend",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(48:25),
+                            Pos(54:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(49:3),
+                                    alias: None,
+                                    name: "foo",
+                                    arguments: [
+                                        (
+                                            "size",
+                                            Variable(
+                                                "size",
+                                            ),
+                                        ),
+                                        (
+                                            "bar",
+                                            Variable(
+                                                "b",
+                                            ),
+                                        ),
+                                        (
+                                            "obj",
+                                            Object(
+                                                {
+                                                    "block": String(
+                                                        "\nblock string uses \"\"\"\n\n",
+                                                    ),
+                                                    "key": String(
+                                                        "value",
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(49:3),
+                                            Pos(49:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+            Operation(
+                SelectionSet(
+                    SelectionSet {
+                        span: (
+                            Pos(56:1),
+                            Pos(59:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(57:3),
+                                    alias: None,
+                                    name: "unnamed",
+                                    arguments: [
+                                        (
+                                            "truthy",
+                                            Boolean(
+                                                true,
+                                            ),
+                                        ),
+                                        (
+                                            "falsey",
+                                            Boolean(
+                                                false,
+                                            ),
+                                        ),
+                                        (
+                                            "nullish",
+                                            Null,
+                                        ),
+                                    ],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(57:3),
+                                            Pos(57:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(58:3),
+                                    alias: None,
+                                    name: "query",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(58:3),
+                                            Pos(58:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_kitchen_sink__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_kitchen_sink__win.snap
@@ -2,8 +2,652 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 10:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(10:1),
+                        description: None,
+                        name: Some(
+                            "queryName",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(10:17),
+                                name: "foo",
+                                var_type: NamedType(
+                                    "ComplexType",
+                                ),
+                                default_value: None,
+                            },
+                            VariableDefinition {
+                                position: Pos(10:36),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Enum(
+                                        "MOBILE",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(10:58),
+                                Pos(29:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(11:3),
+                                        alias: Some(
+                                            "whoever123is",
+                                        ),
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                List(
+                                                    [
+                                                        Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(11:38),
+                                                Pos(28:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(12:5),
+                                                        alias: None,
+                                                        name: "id",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(12:5),
+                                                                Pos(12:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(13:9),
+                                                        type_condition: Some(
+                                                            On(
+                                                                "User",
+                                                            ),
+                                                        ),
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(13:17),
+                                                                name: "defer",
+                                                                arguments: [],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(13:24),
+                                                                Pos(21:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(14:7),
+                                                                        alias: None,
+                                                                        name: "field2",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(14:14),
+                                                                                Pos(20:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(15:9),
+                                                                                        alias: None,
+                                                                                        name: "id",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(15:9),
+                                                                                                Pos(15:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(16:9),
+                                                                                        alias: Some(
+                                                                                            "alias",
+                                                                                        ),
+                                                                                        name: "field1",
+                                                                                        arguments: [
+                                                                                            (
+                                                                                                "first",
+                                                                                                Int(
+                                                                                                    Number(
+                                                                                                        10,
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            (
+                                                                                                "after",
+                                                                                                Variable(
+                                                                                                    "foo",
+                                                                                                ),
+                                                                                            ),
+                                                                                        ],
+                                                                                        directives: [
+                                                                                            Directive {
+                                                                                                position: Pos(16:46),
+                                                                                                name: "include",
+                                                                                                arguments: [
+                                                                                                    (
+                                                                                                        "if",
+                                                                                                        Variable(
+                                                                                                            "foo",
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ],
+                                                                                            },
+                                                                                        ],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(16:65),
+                                                                                                Pos(19:9),
+                                                                                            ),
+                                                                                            items: [
+                                                                                                Field(
+                                                                                                    Field {
+                                                                                                        position: Pos(17:11),
+                                                                                                        alias: None,
+                                                                                                        name: "id",
+                                                                                                        arguments: [],
+                                                                                                        directives: [],
+                                                                                                        selection_set: SelectionSet {
+                                                                                                            span: (
+                                                                                                                Pos(17:11),
+                                                                                                                Pos(17:11),
+                                                                                                            ),
+                                                                                                            items: [],
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                FragmentSpread(
+                                                                                                    FragmentSpread {
+                                                                                                        position: Pos(18:14),
+                                                                                                        fragment_name: "frag",
+                                                                                                        directives: [],
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(22:9),
+                                                        type_condition: None,
+                                                        directives: [
+                                                            Directive {
+                                                                position: Pos(22:9),
+                                                                name: "skip",
+                                                                arguments: [
+                                                                    (
+                                                                        "unless",
+                                                                        Variable(
+                                                                            "foo",
+                                                                        ),
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(22:29),
+                                                                Pos(24:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(23:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(23:7),
+                                                                                Pos(23:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                                InlineFragment(
+                                                    InlineFragment {
+                                                        position: Pos(25:9),
+                                                        type_condition: None,
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(25:9),
+                                                                Pos(27:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(26:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(26:7),
+                                                                                Pos(26:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Operation(
+                Mutation(
+                    Mutation {
+                        position: Pos(31:1),
+                        description: None,
+                        name: Some(
+                            "likeStory",
+                        ),
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(31:20),
+                                Pos(37:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(32:3),
+                                        alias: None,
+                                        name: "like",
+                                        arguments: [
+                                            (
+                                                "story",
+                                                Int(
+                                                    Number(
+                                                        123,
+                                                    ),
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [
+                                            Directive {
+                                                position: Pos(32:20),
+                                                name: "defer",
+                                                arguments: [],
+                                            },
+                                        ],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(32:27),
+                                                Pos(36:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(33:5),
+                                                        alias: None,
+                                                        name: "story",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(33:11),
+                                                                Pos(35:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(34:7),
+                                                                        alias: None,
+                                                                        name: "id",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(34:7),
+                                                                                Pos(34:7),
+                                                                            ),
+                                                                            items: [],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Operation(
+                Subscription(
+                    Subscription {
+                        position: Pos(39:1),
+                        description: None,
+                        name: Some(
+                            "StoryLikeSubscription",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(39:36),
+                                name: "input",
+                                var_type: NamedType(
+                                    "StoryLikeSubscribeInput",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(39:69),
+                                Pos(50:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(40:3),
+                                        alias: None,
+                                        name: "storyLikeSubscribe",
+                                        arguments: [
+                                            (
+                                                "input",
+                                                Variable(
+                                                    "input",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(40:37),
+                                                Pos(49:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(41:5),
+                                                        alias: None,
+                                                        name: "story",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(41:11),
+                                                                Pos(48:5),
+                                                            ),
+                                                            items: [
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(42:7),
+                                                                        alias: None,
+                                                                        name: "likers",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(42:14),
+                                                                                Pos(44:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(43:9),
+                                                                                        alias: None,
+                                                                                        name: "count",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(43:9),
+                                                                                                Pos(43:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                Field(
+                                                                    Field {
+                                                                        position: Pos(45:7),
+                                                                        alias: None,
+                                                                        name: "likeSentence",
+                                                                        arguments: [],
+                                                                        directives: [],
+                                                                        selection_set: SelectionSet {
+                                                                            span: (
+                                                                                Pos(45:20),
+                                                                                Pos(47:7),
+                                                                            ),
+                                                                            items: [
+                                                                                Field(
+                                                                                    Field {
+                                                                                        position: Pos(46:9),
+                                                                                        alias: None,
+                                                                                        name: "text",
+                                                                                        arguments: [],
+                                                                                        directives: [],
+                                                                                        selection_set: SelectionSet {
+                                                                                            span: (
+                                                                                                Pos(46:9),
+                                                                                                Pos(46:9),
+                                                                                            ),
+                                                                                            items: [],
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(52:1),
+                    description: None,
+                    name: "frag",
+                    type_condition: On(
+                        "Friend",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(52:25),
+                            Pos(58:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(53:3),
+                                    alias: None,
+                                    name: "foo",
+                                    arguments: [
+                                        (
+                                            "size",
+                                            Variable(
+                                                "size",
+                                            ),
+                                        ),
+                                        (
+                                            "bar",
+                                            Variable(
+                                                "b",
+                                            ),
+                                        ),
+                                        (
+                                            "obj",
+                                            Object(
+                                                {
+                                                    "block": String(
+                                                        "\nblock string uses \"\"\"\n\n",
+                                                    ),
+                                                    "key": String(
+                                                        "value",
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(53:3),
+                                            Pos(53:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+            Operation(
+                SelectionSet(
+                    SelectionSet {
+                        span: (
+                            Pos(60:1),
+                            Pos(63:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(61:3),
+                                    alias: None,
+                                    name: "unnamed",
+                                    arguments: [
+                                        (
+                                            "truthy",
+                                            Boolean(
+                                                true,
+                                            ),
+                                        ),
+                                        (
+                                            "falsey",
+                                            Boolean(
+                                                false,
+                                            ),
+                                        ),
+                                        (
+                                            "nullish",
+                                            Null,
+                                        ),
+                                    ],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(61:3),
+                                            Pos(61:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(62:3),
+                                    alias: None,
+                                    name: "query",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(62:3),
+                                            Pos(62:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_list_argument__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_list_argument__unix.snap
@@ -2,8 +2,70 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                            (
+                                                "list",
+                                                List(
+                                                    [
+                                                        Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_list_argument__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_list_argument__win.snap
@@ -2,8 +2,70 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                            (
+                                                "list",
+                                                List(
+                                                    [
+                                                        Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_object_argument__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_object_argument__unix.snap
@@ -2,8 +2,70 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                            (
+                                                "obj",
+                                                Object(
+                                                    {
+                                                        "key1": Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        "key2": Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_object_argument__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_object_argument__win.snap
@@ -2,8 +2,70 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                Int(
+                                                    Number(
+                                                        1,
+                                                    ),
+                                                ),
+                                            ),
+                                            (
+                                                "obj",
+                                                Object(
+                                                    {
+                                                        "key1": Int(
+                                                            Number(
+                                                                123,
+                                                            ),
+                                                        ),
+                                                        "key2": Int(
+                                                            Number(
+                                                                456,
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_float__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_float__unix.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Float",
+                                ),
+                                default_value: Some(
+                                    Float(
+                                        0.5,
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:31),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_float__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_float__win.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Float",
+                                ),
+                                default_value: Some(
+                                    Float(
+                                        0.5,
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:31),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_list__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_list__unix.snap
@@ -2,8 +2,72 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: ListType(
+                                    NamedType(
+                                        "Int",
+                                    ),
+                                ),
+                                default_value: Some(
+                                    List(
+                                        [
+                                            Int(
+                                                Number(
+                                                    123,
+                                                ),
+                                            ),
+                                            Int(
+                                                Number(
+                                                    456,
+                                                ),
+                                            ),
+                                        ],
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:38),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_list__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_list__win.snap
@@ -2,8 +2,72 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: ListType(
+                                    NamedType(
+                                        "Int",
+                                    ),
+                                ),
+                                default_value: Some(
+                                    List(
+                                        [
+                                            Int(
+                                                Number(
+                                                    123,
+                                                ),
+                                            ),
+                                            Int(
+                                                Number(
+                                                    456,
+                                                ),
+                                            ),
+                                        ],
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:38),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_object__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_object__unix.snap
@@ -2,8 +2,61 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Object(
+                                        {
+                                            "url": Null,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:38),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_object__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_object__win.snap
@@ -2,8 +2,61 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Object(
+                                        {
+                                            "url": Null,
+                                        },
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:38),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_string__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_string__unix.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "String",
+                                ),
+                                default_value: Some(
+                                    String(
+                                        "string",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:37),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_string__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_default_string__win.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "String",
+                                ),
+                                default_value: Some(
+                                    String(
+                                        "string",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:37),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_defaults__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_defaults__unix.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Enum(
+                                        "MOBILE",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:33),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_var_defaults__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_var_defaults__win.snap
@@ -2,8 +2,59 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "site",
+                                var_type: NamedType(
+                                    "Site",
+                                ),
+                                default_value: Some(
+                                    Enum(
+                                        "MOBILE",
+                                    ),
+                                ),
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:33),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_vars__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_vars__unix.snap
@@ -2,8 +2,55 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "arg",
+                                var_type: NamedType(
+                                    "SomeType",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:27),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__query_vars__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__query_vars__win.snap
@@ -2,8 +2,55 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: Some(
+                            "Foo",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(1:11),
+                                name: "arg",
+                                var_type: NamedType(
+                                    "SomeType",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:27),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "field",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__scalar_type__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__scalar_type__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(2:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__scalar_type__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__scalar_type__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(2:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__unix.snap
@@ -944,6 +944,217 @@ Ok(
                     ],
                 },
             ),
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(119:1),
+                    description: None,
+                    name: "SomeNamedFragment",
+                    type_condition: On(
+                        "SomeType",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(119:40),
+                            Pos(125:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(120:3),
+                                    alias: None,
+                                    name: "fieldOne",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(120:3),
+                                            Pos(120:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(121:3),
+                                    alias: Some(
+                                        "aliased",
+                                    ),
+                                    name: "fieldTwo",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(121:21),
+                                            Pos(123:3),
+                                        ),
+                                        items: [
+                                            Field(
+                                                Field {
+                                                    position: Pos(122:5),
+                                                    alias: None,
+                                                    name: "some",
+                                                    arguments: [],
+                                                    directives: [],
+                                                    selection_set: SelectionSet {
+                                                        span: (
+                                                            Pos(122:10),
+                                                            Pos(122:17),
+                                                        ),
+                                                        items: [
+                                                            Field(
+                                                                Field {
+                                                                    position: Pos(122:12),
+                                                                    alias: None,
+                                                                    name: "deep",
+                                                                    arguments: [],
+                                                                    directives: [],
+                                                                    selection_set: SelectionSet {
+                                                                        span: (
+                                                                            Pos(122:12),
+                                                                            Pos(122:12),
+                                                                        ),
+                                                                        items: [],
+                                                                    },
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(124:3),
+                                    alias: None,
+                                    name: "yetAnother",
+                                    arguments: [],
+                                    directives: [
+                                        Directive {
+                                            position: Pos(124:14),
+                                            name: "withADirective",
+                                            arguments: [
+                                                (
+                                                    "param",
+                                                    Int(
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                ),
+                                                (
+                                                    "enumParam",
+                                                    Enum(
+                                                        "VALUE",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(124:3),
+                                            Pos(124:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(127:1),
+                        description: None,
+                        name: Some(
+                            "StoredQuery",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(127:19),
+                                name: "param",
+                                var_type: NamedType(
+                                    "InputType",
+                                ),
+                                default_value: None,
+                            },
+                            VariableDefinition {
+                                position: Pos(127:38),
+                                name: "other",
+                                var_type: NamedType(
+                                    "ScalarType",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(127:58),
+                                Pos(131:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(128:3),
+                                        alias: None,
+                                        name: "lookup",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(128:10),
+                                                Pos(130:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(129:5),
+                                                        alias: None,
+                                                        name: "various",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(129:5),
+                                                                Pos(129:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                Field(
+                                                    Field {
+                                                        position: Pos(129:13),
+                                                        alias: None,
+                                                        name: "things",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(129:13),
+                                                                Pos(129:13),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
         ],
     },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            SchemaDefinition(
+            Schema(
                 SchemaDefinition {
                     position: Pos(6:1),
                     directives: [],
@@ -18,7 +18,7 @@ Ok(
                     subscription: None,
                 },
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(15:1),
@@ -211,7 +211,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(25:1),
@@ -274,7 +274,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(29:1),
@@ -338,7 +338,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(37:1),
@@ -386,7 +386,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(42:1),
@@ -438,7 +438,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(46:1),
@@ -500,7 +500,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(54:1),
@@ -515,7 +515,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(56:1),
@@ -535,7 +535,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(58:1),
@@ -555,7 +555,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(60:1),
@@ -595,7 +595,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(66:1),
@@ -605,7 +605,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(68:1),
@@ -636,7 +636,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(72:1),
@@ -660,7 +660,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(77:1),
@@ -696,7 +696,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(82:1),
@@ -740,7 +740,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(90:1),
@@ -780,7 +780,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(95:1),
@@ -814,7 +814,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(99:1),
@@ -866,7 +866,7 @@ Ok(
                     },
                 ),
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(107:1),
                     description: None,
@@ -892,7 +892,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(109:1),
                     description: None,
@@ -918,7 +918,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(114:1),
                     description: None,

--- a/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__win.snap
@@ -944,6 +944,217 @@ Ok(
                     ],
                 },
             ),
+            Fragment(
+                FragmentDefinition {
+                    position: Pos(123:1),
+                    description: None,
+                    name: "SomeNamedFragment",
+                    type_condition: On(
+                        "SomeType",
+                    ),
+                    directives: [],
+                    selection_set: SelectionSet {
+                        span: (
+                            Pos(123:40),
+                            Pos(129:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(124:3),
+                                    alias: None,
+                                    name: "fieldOne",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(124:3),
+                                            Pos(124:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(125:3),
+                                    alias: Some(
+                                        "aliased",
+                                    ),
+                                    name: "fieldTwo",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(125:21),
+                                            Pos(127:3),
+                                        ),
+                                        items: [
+                                            Field(
+                                                Field {
+                                                    position: Pos(126:5),
+                                                    alias: None,
+                                                    name: "some",
+                                                    arguments: [],
+                                                    directives: [],
+                                                    selection_set: SelectionSet {
+                                                        span: (
+                                                            Pos(126:10),
+                                                            Pos(126:17),
+                                                        ),
+                                                        items: [
+                                                            Field(
+                                                                Field {
+                                                                    position: Pos(126:12),
+                                                                    alias: None,
+                                                                    name: "deep",
+                                                                    arguments: [],
+                                                                    directives: [],
+                                                                    selection_set: SelectionSet {
+                                                                        span: (
+                                                                            Pos(126:12),
+                                                                            Pos(126:12),
+                                                                        ),
+                                                                        items: [],
+                                                                    },
+                                                                },
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                },
+                            ),
+                            Field(
+                                Field {
+                                    position: Pos(128:3),
+                                    alias: None,
+                                    name: "yetAnother",
+                                    arguments: [],
+                                    directives: [
+                                        Directive {
+                                            position: Pos(128:14),
+                                            name: "withADirective",
+                                            arguments: [
+                                                (
+                                                    "param",
+                                                    Int(
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                ),
+                                                (
+                                                    "enumParam",
+                                                    Enum(
+                                                        "VALUE",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(128:3),
+                                            Pos(128:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                },
+            ),
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(131:1),
+                        description: None,
+                        name: Some(
+                            "StoredQuery",
+                        ),
+                        variable_definitions: [
+                            VariableDefinition {
+                                position: Pos(131:19),
+                                name: "param",
+                                var_type: NamedType(
+                                    "InputType",
+                                ),
+                                default_value: None,
+                            },
+                            VariableDefinition {
+                                position: Pos(131:38),
+                                name: "other",
+                                var_type: NamedType(
+                                    "ScalarType",
+                                ),
+                                default_value: None,
+                            },
+                        ],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(131:58),
+                                Pos(135:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(132:3),
+                                        alias: None,
+                                        name: "lookup",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(132:10),
+                                                Pos(134:3),
+                                            ),
+                                            items: [
+                                                Field(
+                                                    Field {
+                                                        position: Pos(133:5),
+                                                        alias: None,
+                                                        name: "various",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(133:5),
+                                                                Pos(133:5),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                                Field(
+                                                    Field {
+                                                        position: Pos(133:13),
+                                                        alias: None,
+                                                        name: "things",
+                                                        arguments: [],
+                                                        directives: [],
+                                                        selection_set: SelectionSet {
+                                                            span: (
+                                                                Pos(133:13),
+                                                                Pos(133:13),
+                                                            ),
+                                                            items: [],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
         ],
     },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__schema_kitchen_sink__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            SchemaDefinition(
+            Schema(
                 SchemaDefinition {
                     position: Pos(10:1),
                     directives: [],
@@ -18,7 +18,7 @@ Ok(
                     subscription: None,
                 },
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(19:1),
@@ -211,7 +211,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(29:1),
@@ -274,7 +274,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(33:1),
@@ -338,7 +338,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(41:1),
@@ -386,7 +386,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(46:1),
@@ -438,7 +438,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Interface(
                     InterfaceType {
                         position: Pos(50:1),
@@ -500,7 +500,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(58:1),
@@ -515,7 +515,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(60:1),
@@ -535,7 +535,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(62:1),
@@ -555,7 +555,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(64:1),
@@ -595,7 +595,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(70:1),
@@ -605,7 +605,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Scalar(
                     ScalarType {
                         position: Pos(72:1),
@@ -636,7 +636,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(76:1),
@@ -660,7 +660,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(81:1),
@@ -696,7 +696,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 Enum(
                     EnumType {
                         position: Pos(86:1),
@@ -740,7 +740,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(94:1),
@@ -780,7 +780,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(99:1),
@@ -814,7 +814,7 @@ Ok(
                     },
                 ),
             ),
-            TypeDefinition(
+            Type(
                 InputObject(
                     InputObjectType {
                         position: Pos(103:1),
@@ -866,7 +866,7 @@ Ok(
                     },
                 ),
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(111:1),
                     description: None,
@@ -892,7 +892,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(113:1),
                     description: None,
@@ -918,7 +918,7 @@ Ok(
                     ],
                 },
             ),
-            DirectiveDefinition(
+            Directive(
                 DirectiveDefinition {
                     position: Pos(118:1),
                     description: None,

--- a/graphql-parser/tests/snapshots/tests__parse_schema__simple_object__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__simple_object__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__simple_object__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__simple_object__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Object(
                     ObjectType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__string_literal__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__string_literal__unix.snap
@@ -2,8 +2,51 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                String(
+                                                    "hello",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__string_literal__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__string_literal__win.snap
@@ -2,8 +2,51 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                String(
+                                                    "hello",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__subscription_directive__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__subscription_directive__unix.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `subscription[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Subscription(
+                    Subscription {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:14),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:25),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__subscription_directive__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__subscription_directive__win.snap
@@ -2,8 +2,50 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `subscription[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Subscription(
+                    Subscription {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [
+                            Directive {
+                                position: Pos(1:14),
+                                name: "directive",
+                                arguments: [],
+                            },
+                        ],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:25),
+                                Pos(3:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__triple_quoted_literal__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__triple_quoted_literal__unix.snap
@@ -2,8 +2,51 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(6:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                String(
+                                                    "Hello,\n  world!\n",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__triple_quoted_literal__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__triple_quoted_literal__win.snap
@@ -2,8 +2,51 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `query[Name]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                Query(
+                    Query {
+                        position: Pos(1:1),
+                        description: None,
+                        name: None,
+                        variable_definitions: [],
+                        directives: [],
+                        selection_set: SelectionSet {
+                            span: (
+                                Pos(1:7),
+                                Pos(6:1),
+                            ),
+                            items: [
+                                Field(
+                                    Field {
+                                        position: Pos(2:3),
+                                        alias: None,
+                                        name: "node",
+                                        arguments: [
+                                            (
+                                                "id",
+                                                String(
+                                                    "Hello,\n  world!\n",
+                                                ),
+                                            ),
+                                        ],
+                                        directives: [],
+                                        selection_set: SelectionSet {
+                                            span: (
+                                                Pos(2:3),
+                                                Pos(2:3),
+                                            ),
+                                            items: [],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__union__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__union__unix.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__union__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__union__win.snap
@@ -5,7 +5,7 @@ expression: result
 Ok(
     Document {
         definitions: [
-            TypeDefinition(
+            Type(
                 Union(
                     UnionType {
                         position: Pos(1:1),

--- a/graphql-parser/tests/snapshots/tests__parse_schema__very_minimal_query__unix.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__very_minimal_query__unix.snap
@@ -2,8 +2,37 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `{[Punctuator]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                SelectionSet(
+                    SelectionSet {
+                        span: (
+                            Pos(1:1),
+                            Pos(3:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(2:3),
+                                    alias: None,
+                                    name: "a",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(2:3),
+                                            Pos(2:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ],
+    },
 )

--- a/graphql-parser/tests/snapshots/tests__parse_schema__very_minimal_query__win.snap
+++ b/graphql-parser/tests/snapshots/tests__parse_schema__very_minimal_query__win.snap
@@ -2,8 +2,37 @@
 source: graphql-parser/tests/tests.rs
 expression: result
 ---
-Err(
-    ParseError(
-        "Parse error at 1:1\nUnexpected `{[Punctuator]`\nExpected `schema`, `extend`, `scalar`, `type`, `interface`, `union`, `enum`, `input` or `directive`\n",
-    ),
+Ok(
+    Document {
+        definitions: [
+            Operation(
+                SelectionSet(
+                    SelectionSet {
+                        span: (
+                            Pos(1:1),
+                            Pos(3:1),
+                        ),
+                        items: [
+                            Field(
+                                Field {
+                                    position: Pos(2:3),
+                                    alias: None,
+                                    name: "a",
+                                    arguments: [],
+                                    directives: [],
+                                    selection_set: SelectionSet {
+                                        span: (
+                                            Pos(2:3),
+                                            Pos(2:3),
+                                        ),
+                                        items: [],
+                                    },
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ],
+    },
 )


### PR DESCRIPTION
Enable dropping named queries and fragments into the SDL. The typescript parser allows this, and even if it didn't, we need to be able to point tooling at a graphql file and parse whatever's inside of it to e.g. do codegen on stored queries.

The parser here is a bit more permissive than I think we'll want the actual language to be. For instance, it's okay with you putting a bare, unnamed `query` into a schema file:

```graphql
query { some { stuff } }
```

I don't think we actually want that—I don't know what it means, really, or what we'd want to do with it (suggestions welcome tho!) That said, I think it's probably better that the parser doesn't barf on it, and instead that we treat it as a semantic error at some higher level of atlas or forge.