### PR TITLE
Initial windows installer experience

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,13 +26,19 @@ This will download the latest release from GitHub and install the binary at your
 
 The curl script accepts to variables if you want to customize the install. To change the destination you can set the `DESTDIR` variable to a new location (`curl -sSL https://install.apollographql.com/ | DESTDIR=/opt/bin sh`). If you wan to install a specific version, you can set the `VERSION` variable in the same way as the `DESTDIR` (`curl -sSL https://install.apollographql.com/ | VERSION=0.0.1 sh`)
 
-> **Coming soon**: If you have `npm` already installed, and are comfortable with the node ecosystem, you can also install the library using `npm i -g @apollo/cli`. This will install a global version of the package which downloads the CLI just like the curl command does.
-
 **Windows** users:
 
-The curl command doesn’t currently support windows (though we want it to in the future). Right now the best way to get the latest CLI is to go to the [releases](<[https://github.com/apollographql/apollo-cli/releases/latest](https://github.com/apollographql/apollo-cli/releases/tag/v0.0.1)>) page and download the windows tarball. In the future, you will be able to install the CLI using chocolatey.
+Make sure [PowerShell 5](https://aka.ms/wmf5download) (or later, include [PowerShell Core](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows?view=powershell-6)) and [].NET Framework 4.5](https://www.microsoft.com/net/download) (or later) are installed. Then run:
 
-> **Coming soon**: If you have `npm` already installed, and are comfortable with the node ecosystem, you can also install the library using `npm i -g @apollo/cli`. This will install a global version of the package which downloads the CLI just like the curl command does.
+```ps1
+iwr 'https://install.apollographql.com/windows.sh' | iex
+```
+
+> Note: if you get an error you might need to change the execution policy (i.e. enable Powershell) with
+
+```ps1
+Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+```
 
 **Verifying the Install**
 
@@ -40,7 +46,7 @@ If you want to verify the binary you have installed, each [release]([https://git
 
 ### On your CI provider
 
-The Apollo CLI is designed to be installed quickly and easily on common CI platforms. For build systems using **Mac OS** or **Linux**, the curl command above is the fastest way to get the CLI installed. For Windows, right now the best option is to manually copy the url of the latest release and unpack it on your machine. The `npm` route will be easier and faster and is coming soon!
+The Apollo CLI is designed to be installed quickly and easily on common CI platforms. For build systems using **Mac OS** or **Linux**, the curl command above is the fastest way to get the CLI installed. For Windows, the `iwr` command above should get you up and running right away!
 
 ## Updating the CLI
 
@@ -58,7 +64,7 @@ The Apollo CLI is designed to make working with you data graph and code base as 
 
 The CLI has a top level help command which prints out all of the possible commands, an initial getting started guide, common flags, and the version of the command you are running. To view this, run the following command in your terminal:
 
-`apollo help`
+`ap help`
 
 If you want to learn more about any commands, you can run `--help` as a flag for any subcommand. An example of this may look like `ap login --help` (when it is built!) which will print out information on using the login command to link you Apollo account to your system. 
 

--- a/cdn/Readme.md
+++ b/cdn/Readme.md
@@ -21,9 +21,17 @@ The worker is a simple routing application that has a few simple routes. It is c
 The worker is deployed to Cloudflare's global worker runtime and uses their `KV` cache to cache static assets. It reads the `ETAG` and other cache headers of responses from GitHub Releases to cache tarballs all around the globe for faster and more robust uptimes.
 
 ### Installer
-The installers are the main `install.sh` for a given project (currently just for the new CLI) which is installed via a `curl` command. This installer is designed to be run on users machines __and__ on CI environments to support usage of the Apollo CLI on those machines with a single __copyable__ command.
+There are two installers supported by the CDN. First is the nix `install.sh` installer for the new CLI which is installed via a `curl` command. This installer is designed to be run on users machines __and__ on CI environments to support usage of the Apollo CLI on those machines with a single __copyable__ command.
 
-The current installer only supports `linux` and `darwin` architectures but we would like to expand to `windows` in the future if possible.
+The nix installer only supports `linux` and `darwin` architectures.
+
+For installation on windows we provide a powershell installer at `windows.sh`
+> This file is listed as a .sh file even though it really is ps1 due to quirk in Cloudflare workers not resovling ps1 urls?
+
+To install on windows, people can run the following:
+```ps1
+iwr 'http://install.apollographql.com/windows.sh' | iex
+```
 
 ## Local Development
 

--- a/cdn/package-lock.json
+++ b/cdn/package-lock.json
@@ -1515,6 +1515,30 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@zeit/fetch-retry": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@zeit/fetch-retry/-/fetch-retry-5.0.0.tgz",
+      "integrity": "sha512-48tgGYYNX4AGyR8LZa5nMGdr3j4VXYxAA7BX6RWSKIWZkdh1bbkUB6M9ZLfmxsED0CEGpJmP7svN8qnolwZ45w==",
+      "requires": {
+        "async-retry": "^1.3.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -1845,6 +1869,14 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "requires": {
+        "retry": "0.12.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -7382,6 +7414,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
       "version": "2.7.1",

--- a/cdn/package.json
+++ b/cdn/package.json
@@ -14,7 +14,7 @@
     "uuid-browser": "^3.1.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^1.0.1",
+    "@cloudflare/workers-types": "^1.0.9",
     "@cloudflare/wrangler": "^1.8.4",
     "@types/fetch-mock": "^7.3.2",
     "@types/jest": "^25.2.1",

--- a/cdn/package.json
+++ b/cdn/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.0.9",
+    "@zeit/fetch-retry": "^5.0.0",
     "uuid-browser": "^3.1.0"
   },
   "devDependencies": {

--- a/cdn/public/windows.sh
+++ b/cdn/public/windows.sh
@@ -1,0 +1,123 @@
+#Requires -Version 5
+
+# This file is listed as a .sh file because cloudflare workers
+# won't serve a ps1 file for some unknown reason?!
+# 
+# To install, run:
+#   iwr 'http://install.apollographql.com/windows.sh' | iex
+$old_erroractionpreference = $erroractionpreference
+$erroractionpreference = 'stop' # quit if anything goes wrong
+
+function info($msg) {  write-host "> $msg" -f white }
+function warn($msg) {  write-host "! $msg" -f darkyellow }
+function err($msg) { write-host "x $msg" -f darkred }
+function complete($msg) { write-host "✓ $msg" -f darkgreen }
+
+function mktemp {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string] $name = [System.Guid]::NewGuid()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function is_directory([String] $path) {
+    return (Test-Path $path) -and (Get-Item $path) -is [System.IO.DirectoryInfo]
+}
+
+function installed($app) {
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'stop'
+    try {if(Get-Command $command){RETURN $true}}
+    Catch {RETURN $false}
+    Finally {$ErrorActionPreference=$oldPreference}
+}
+
+function Get-UserAgent() {
+    return "Apollo CLI/0.1 PowerShell/$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) (Windows NT $([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor); $(if($env:PROCESSOR_ARCHITECTURE -eq 'AMD64'){'Win64; x64; '})$(if($env:PROCESSOR_ARCHITEW6432 -eq 'AMD64'){'WOW64; '})$PSEdition)"
+}
+function dl($url,$to) {
+    $wc = New-Object Net.Webclient
+    $wc.Headers.Add('User-Agent', (Get-UserAgent))
+    $wc.downloadFile($url,$to)
+}
+
+$_tmp = mktemp 
+$apollo = "$HOME\.apollo\bin"
+
+function check_environment_readiness() {
+
+    if (($PSVersionTable.PSVersion.Major) -lt 5) {
+        err "PowerShell 5 or later is required to run the Apollo CLI."
+        err "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+        break
+    }
+
+    # show notification to change execution policy:
+    $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
+    if ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
+        err "PowerShell requires an execution policy in [$($allowedExecutionPolicy -join ", ")] to run the Apollo CLI."
+        err "For example, to set the execution policy to 'RemoteSigned' please run :"
+        err "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
+        break
+    }
+
+    # GitHub requires TLS 1.2
+    if ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'Tls12') {
+        err "Installing the Apollo CLI requires at least .NET Framework 4.5"
+        err "Please download and install it first:"
+        err "https://www.microsoft.com/net/download"
+        break
+    }
+
+    # XXX check curl + tar installations
+    # error "The curl command is not installed on this machine. Please install curl before installing the Apollo CLI"
+    # error "The tar command is not installed on this machine. Please install tar before installing the Apollo CLI"
+
+    if (installed 'ap') {
+        err "The Apollo CLI is already installed. Please remove it before installing a new version." -f red
+        # don't abort if invoked with iex that would close the PS session
+        if ($myinvocation.mycommand.commandtype -eq 'Script') { return } else { exit 1 }
+    }
+}
+
+function download_and_install() {
+    mkdir "$apollo" -ea 0
+
+    download_from_proxy
+
+    Copy-Item "$_tmp\dist\ap.exe" "$apollo" -Recurse -Force
+    Remove-Item "$_tmp" -Recurse -Force
+
+    "$apollo\ap.exe setup"
+}
+
+function download_from_proxy() {
+    # download CLI tarball
+    $tar_url = 'https://install.apollographql.com/cli/windows'
+    $tar_file = "$_tmp\ap.tar.gz"
+    dl $tar_url $tar_file
+
+    tar -xkf $tar_file -C "$_tmp"
+}
+
+function run_main() {
+    info "Installing Apollo CLI...`n"
+
+    Write-Output "  `e[4mConfiguration`e[24m"
+    info "Bin directory:  $apollo"
+    info "Platform:       windows"
+    info "Version:        latest"
+
+    check_environment_readiness
+
+    Write-Output "`n"
+
+    info "Installing the Apollo CLI to $apollo...`n"
+
+    download_and_install
+
+    complete "Apollo CLI was successfully installed!"
+}
+
+run_main
+
+$erroractionpreference = $old_erroractionpreference # Reset $erroractionpreference to original value

--- a/cdn/public/windows.sh
+++ b/cdn/public/windows.sh
@@ -87,7 +87,7 @@ function download_and_install() {
     Copy-Item "$_tmp\dist\ap.exe" "$apollo" -Recurse -Force
     Remove-Item "$_tmp" -Recurse -Force
 
-    "$apollo\ap.exe setup"
+    "$apollo\ap.exe setup" | Invoke-Expression
 }
 
 function download_from_proxy() {

--- a/cdn/src/handler.ts
+++ b/cdn/src/handler.ts
@@ -97,7 +97,7 @@ async function handleCLI(
   // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
   const response = await fetch(
     `${GITHUB_RELEASE}/download/v${version}/ap-v${version}-${platform}.tar.gz`,
-    { method, body, cf: { cacheEverything: true } }
+    { method, body, cf: { cacheEverything: true, cacheTtl: 3600 } } as any
   );
 
   if (response.ok) {

--- a/cdn/src/handler.ts
+++ b/cdn/src/handler.ts
@@ -4,6 +4,9 @@ import {
 } from "@cloudflare/kv-asset-handler";
 import { log } from "./sentry";
 import { handleLegacyCLI } from "./legacy-cli";
+import setup from "@zeit/fetch-retry";
+
+const f = setup(fetch);
 
 const GITHUB_RELEASE = "https://github.com/apollographql/apollo-cli/releases";
 
@@ -82,7 +85,7 @@ async function handleCLI(
 ): Promise<Response> {
   if (platform && !version) {
     // fetch latest version number
-    const response = await fetch(`${GITHUB_RELEASE}/latest`, { cf: { cacheEverything: true } });
+    const response = await f(`${GITHUB_RELEASE}/latest`, { cf: { cacheEverything: true } });
     if (!response.ok) {
       throw new Error(
         `Error loading latest release for CLI at ${GITHUB_RELEASE}/latest`
@@ -95,7 +98,7 @@ async function handleCLI(
 
   const { method, body } = event.request;
   // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
-  const response = await fetch(
+  const response = await f(
     `${GITHUB_RELEASE}/download/v${version}/ap-v${version}-${platform}.tar.gz`,
     { method, body, cf: { cacheEverything: true, cacheTtl: 3600 } } as any
   );

--- a/cdn/src/legacy-cli.test.ts
+++ b/cdn/src/legacy-cli.test.ts
@@ -1,6 +1,8 @@
 import { mockGlobal } from './mock'
 import fetchMock from 'fetch-mock'
 jest.mock('./sentry')
+jest.mock('@zeit/fetch-retry', () => (f: any) => f);
+
 
 const GITHUB_RELEASE =
   "https://github.com/apollographql/apollo-tooling/releases";

--- a/cdn/src/legacy-cli.ts
+++ b/cdn/src/legacy-cli.ts
@@ -14,7 +14,7 @@ export async function handleLegacyCLI(
   // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
   const response = await fetch(
     `${GITHUB_RELEASE}/download/apollo@${version}/apollo-v${version}-darwin-x64.tar.gz`,
-    { method, body, cf: { cacheEverything: true } }
+    { method, body, cf: { cacheEverything: true, cacheTtl: 3600 } } as any // cloudflare types doesn't include cacheTtl
   );
 
   if (response.ok) {

--- a/cdn/src/legacy-cli.ts
+++ b/cdn/src/legacy-cli.ts
@@ -1,3 +1,5 @@
+import setup from "@zeit/fetch-retry";
+
 const GITHUB_RELEASE =
   "https://github.com/apollographql/apollo-tooling/releases";
 
@@ -12,7 +14,7 @@ export async function handleLegacyCLI(
 ): Promise<Response> {
   const { method, body } = event.request;
   // this only supports 64 bit architectures. I don't see us changing this but if we do, this will become gross
-  const response = await fetch(
+  const response = await setup(fetch)(
     `${GITHUB_RELEASE}/download/apollo@${version}/apollo-v${version}-darwin-x64.tar.gz`,
     { method, body, cf: { cacheEverything: true, cacheTtl: 3600 } } as any // cloudflare types doesn't include cacheTtl
   );

--- a/cdn/src/sentry.test.ts
+++ b/cdn/src/sentry.test.ts
@@ -1,5 +1,6 @@
 import { mockGlobal } from "./mock";
 import fetchMock from "fetch-mock";
+jest.mock('@zeit/fetch-retry', () => (f: any) => f);
 
 const GITHUB_RELEASE = "https://github.com/apollographql/apollo-cli/releases";
 beforeEach(() => {

--- a/cdn/src/worker.test.ts
+++ b/cdn/src/worker.test.ts
@@ -1,6 +1,7 @@
 import { mockGlobal } from './mock'
 import fetchMock from 'fetch-mock'
-jest.mock('./sentry')
+jest.mock('./sentry');
+jest.mock('@zeit/fetch-retry', () => (f: any) => f);
 
 const GITHUB_RELEASE = "https://github.com/apollographql/apollo-cli/releases";
 beforeEach(() => {

--- a/cdn/tsconfig.json
+++ b/cdn/tsconfig.json
@@ -13,7 +13,7 @@
   },
   "include": [
     "./src/*.ts",
-    "./types/*.d.ts",
+    "./types/**/*.d.ts",
     "./node_modules/@cloudflare/workers-types/index.d.ts"
   ],
   "exclude": ["node_modules/", "dist/"]

--- a/cdn/types/@zeit/fetch-retry.d.ts
+++ b/cdn/types/@zeit/fetch-retry.d.ts
@@ -1,0 +1,3 @@
+declare module '@zeit/fetch-retry' {
+  export default function setup<T>(fetch: T): T
+}


### PR DESCRIPTION
Turns out that windows has come a long way and now ships with both curl and tar since 2018 🎉. This PR opens up an installer for windows users which is a close match to the experience for *nix users. It doesn't have the GitHub fallback and doesn't have a test suite currently but it does work well from my testing.

To install it (once this has landed) all windows users will need to do is paste this into their powershell

```ps1
iwr 'http://install.apollographql.com/windows.sh' | iex
```

![windows_installer](https://user-images.githubusercontent.com/4967600/81764488-b07e4e80-949f-11ea-87b1-b02f5363ace1.gif)

> I'm not sure why Cloudflare won't resolve a .ps1 file so I've named the file .sh for now which *works* but is odd