### PR TITLE
Gravity/auth setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > for libraries or other packages, see their directories
 
-All notable changes to this project will be documented in this file. __This file is used to generate release information__
+All notable changes to this project will be documented in this file. **This file is used to generate release information**
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.0.3] - 2020-05-11
+
 ### Added
+
 - Added hidden `print` command for printing out GraphQL Documents when debugging
 - Added new logger and error handling internally:
 
@@ -25,15 +27,21 @@ There are two flags that are used to control log levels, `--verbose` and `--quie
 Flags will take precedence over any `APOLLO_LOG_LEVEL` env variable, and trying to use both at the same time will result in a warning.
 
 ### Breaking
+
 - moved installation from /usr/local/bin to ~/.apollo/bin with setup of profile
 
 ## [0.0.2] - 2020-04-23
+
 ### Added
+
 - Setup new basic structure for commands including unimplemented `login` command
 
 ### Breaking
+
 - Renamed the CLI from `apollo` to `ap` while there are still two Apollo CLIs in use by teams
 
 ## [0.0.1] - 2020-04-11
+
 ### Added
+
 - Automated distribution and release pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `auth setup`: A helper command which walks users through adding an Apollo Personal API key.
+
 ## [0.0.3] - 2020-05-11
 
 ### Added

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -75,7 +75,7 @@ impl Subcommand {
             Subcommand::Setup(setup) => setup.run(session),
             Subcommand::Auth(auth) => match auth {
                 commands::Auth::Setup(setup) => setup.run(session),
-            }
+            },
         }
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -62,6 +62,9 @@ pub enum Subcommand {
     #[structopt(name = "setup", setting = AppSettings::Hidden)]
     ///  🚜  setup the Apollo toolchain in your environment
     Setup(commands::Setup),
+    #[structopt(name = "auth")]
+    ///  🔐 Manage authentication
+    Auth(commands::Auth),
 }
 
 impl Subcommand {
@@ -70,6 +73,9 @@ impl Subcommand {
             Subcommand::Update(update) => update.run(session),
             Subcommand::Print(print) => print.run(session),
             Subcommand::Setup(setup) => setup.run(session),
+            Subcommand::Auth(auth) => match auth {
+                commands::Auth::Setup(setup) => setup.run(session),
+            }
         }
     }
 }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -2,7 +2,7 @@ use crate::commands::Command;
 use crate::config::CliConfig;
 use crate::errors::{ExitCode, Fallible};
 use crate::telemetry::Session;
-use crate::terminal::input;
+use crate::terminal::{confirm, input};
 use log::warn;
 use structopt::StructOpt;
 
@@ -20,6 +20,14 @@ pub struct Setup {}
 impl Command for Setup {
     fn run(&self, _session: &mut Session) -> Fallible<ExitCode> {
         let mut config = CliConfig::load().unwrap();
+
+        if config.api_key.is_some() {
+            warn!("Config auth already setup.");
+
+            if !confirm("Proceed?")? {
+                return Ok(ExitCode::Success);
+            }
+        }
 
         let key = input("Please paste key:")?;
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -38,11 +38,10 @@ impl Command for Setup {
         }
 
         debug!("Setting new key...");
-        let mut config = session.config.clone();
-        config.api_key = Some(key);
+        session.config.api_key = Some(key.to_string());
 
         debug!("Saving new key...");
-        CliConfig::save(&session.config_path, &config)?;
+        CliConfig::save(&session.config_path, &session.config)?;
 
         info!("{} Your personal API key was successfuly set!", KEY);
         Ok(ExitCode::Success)

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -3,7 +3,7 @@ use crate::config::CliConfig;
 use crate::errors::{ExitCode, Fallible};
 use crate::style::KEY;
 use crate::telemetry::Session;
-use crate::terminal::{input};
+use crate::terminal::input;
 use console::style;
 use log::{info, warn};
 use structopt::StructOpt;
@@ -22,9 +22,8 @@ pub struct Setup {}
 impl Command for Setup {
     fn run(&self, session: &mut Session) -> Fallible<ExitCode> {
         session.log_command("auth setup");
-        let mut config = CliConfig::load().unwrap();
 
-        if config.api_key.is_some() {
+        if session.config.api_key.is_some() {
             warn!("Authentication already configured.");
         }
 
@@ -37,6 +36,7 @@ impl Command for Setup {
             return Ok(ExitCode::ConfigurationError);
         }
 
+        let mut config = session.config.clone();
         config.api_key = Some(key);
         CliConfig::write(&config).unwrap();
         info!("{} Your personal API key was successfuly set!", KEY);

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -38,7 +38,7 @@ impl Command for Setup {
 
         let mut config = session.config.clone();
         config.api_key = Some(key);
-        CliConfig::write(&config).unwrap();
+        CliConfig::save(&session.config_path, &config).unwrap();
         info!("{} Your personal API key was successfuly set!", KEY);
         Ok(ExitCode::Success)
     }

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -1,0 +1,25 @@
+use crate::commands::Command;
+use crate::errors::{Fallible, ExitCode};
+use crate::telemetry::Session;
+use structopt::StructOpt;
+use crate::config::CliConfig;
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub enum Auth {
+    /// Setup your auth stuff
+    Setup(Setup)
+}
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Setup {}
+
+impl Command for Setup {
+    fn run(&self, session: &mut Session) -> Fallible<ExitCode> {
+        let mut config = CliConfig::load().unwrap();
+        config.api_key = Some(String::from("test"));
+        CliConfig::write(&config).unwrap();
+        Ok(ExitCode::Success)
+    }
+}

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -29,7 +29,7 @@ impl Command for Setup {
 
         info!("To link your CLI to your Apollo account go to {} and create a new Personal API Key. Once you've done that, copy the key and paste it into the prompt below.",
             style("https://engine.apollographql.com/user-settings").cyan());
-        let key = sensitive("User key:")?;
+        let key = sensitive("Personal API Key:")?;
 
         debug!("Checking user input...");
         if key.is_empty() {

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -3,13 +3,15 @@ use crate::config::CliConfig;
 use crate::errors::{ExitCode, Fallible};
 use crate::telemetry::Session;
 use crate::terminal::{confirm, input};
-use log::warn;
+use log::{info, warn};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub enum Auth {
     /// Setup your auth stuff
+    /// Requires using an User key which can be found here:
+    /// https://engine.apollographql.com/user-settings
     Setup(Setup),
 }
 
@@ -29,7 +31,8 @@ impl Command for Setup {
             }
         }
 
-        let key = input("Please paste key:")?;
+        info!("Please input a User key which can be found here: https://engine.apollographql.com/user-settings");
+        let key = input("User key:", true)?;
 
         if key.is_empty() {
             warn!("Did not update the Apollo CLI Config!");

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -3,7 +3,7 @@ use crate::config::CliConfig;
 use crate::errors::{ExitCode, Fallible};
 use crate::style::KEY;
 use crate::telemetry::Session;
-use crate::terminal::input;
+use crate::terminal::sensitive;
 use console::style;
 use log::{info, warn};
 use structopt::StructOpt;
@@ -29,7 +29,7 @@ impl Command for Setup {
 
         info!("To link your CLI to your Apollo account go to {} and create a new Personal API Key. Once you've done that, copy the key and paste it into the prompt below.",
             style("https://engine.apollographql.com/user-settings").cyan());
-        let key = input("User key:", true)?;
+        let key = sensitive("User key:")?;
 
         if key.is_empty() {
             warn!("No key was inputed, quitting without changes.");

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -3,7 +3,7 @@ use crate::config::CliConfig;
 use crate::errors::{ExitCode, Fallible};
 use crate::style::KEY;
 use crate::telemetry::Session;
-use crate::terminal::{confirm, input};
+use crate::terminal::{input};
 use console::style;
 use log::{info, warn};
 use structopt::StructOpt;
@@ -26,10 +26,6 @@ impl Command for Setup {
 
         if config.api_key.is_some() {
             warn!("Authentication already configured.");
-
-            if !confirm("Proceed?")? {
-                return Ok(ExitCode::Success);
-            }
         }
 
         info!("To link your CLI to your Apollo account go to {} and create a new Personal API Key. Once you've done that, copy the key and paste it into the prompt below.",

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -1,14 +1,16 @@
 use crate::commands::Command;
-use crate::errors::{Fallible, ExitCode};
-use crate::telemetry::Session;
-use structopt::StructOpt;
 use crate::config::CliConfig;
+use crate::errors::{ExitCode, Fallible};
+use crate::telemetry::Session;
+use crate::terminal::input;
+use log::warn;
+use structopt::StructOpt;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub enum Auth {
     /// Setup your auth stuff
-    Setup(Setup)
+    Setup(Setup),
 }
 
 #[derive(StructOpt)]
@@ -16,9 +18,17 @@ pub enum Auth {
 pub struct Setup {}
 
 impl Command for Setup {
-    fn run(&self, session: &mut Session) -> Fallible<ExitCode> {
+    fn run(&self, _session: &mut Session) -> Fallible<ExitCode> {
         let mut config = CliConfig::load().unwrap();
-        config.api_key = Some(String::from("test"));
+
+        let key = input("Please paste key:")?;
+
+        if key.is_empty() {
+            warn!("Did not update the Apollo CLI Config!");
+            return Ok(ExitCode::Success);
+        }
+
+        config.api_key = Some(key);
         CliConfig::write(&config).unwrap();
         Ok(ExitCode::Success)
     }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,10 +1,12 @@
 pub mod print;
 pub mod setup;
 pub mod update;
+pub mod auth;
 
 pub use print::Print;
 pub use setup::Setup;
 pub use update::Update;
+pub use auth::Auth;
 
 use crate::errors::{ExitCode, Fallible};
 use crate::telemetry::Session;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,12 +1,12 @@
+pub mod auth;
 pub mod print;
 pub mod setup;
 pub mod update;
-pub mod auth;
 
+pub use auth::Auth;
 pub use print::Print;
 pub use setup::Setup;
 pub use update::Update;
-pub use auth::Auth;
 
 use crate::errors::{ExitCode, Fallible};
 use crate::telemetry::Session;

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -31,9 +31,9 @@ impl Command for Update {
             filename,
             url,
         } = get_latest_release()
-            .map_err(|e| ErrorDetails::CLIInstallError { msg: e.to_string() })?;
+            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
         let current_version = get_installed_version()
-            .map_err(|e| ErrorDetails::CLIInstallError { msg: e.to_string() })?;
+            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
 
         debug!(
             "Comparing installed version {} with latest version {}",
@@ -81,7 +81,7 @@ impl Command for Update {
         );
 
         let mut tmp_archive = File::create(&tmp_archive_path)
-            .map_err(|e| ErrorDetails::CLIInstallError { msg: e.to_string() })?;
+            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
 
         info!("Downloading latest build...");
         let mut download = Download::from_url(&url);
@@ -99,7 +99,7 @@ impl Command for Update {
         let archive_bin_path = format!("dist/{}{}", archive_bin_name, EXE_SUFFIX);
         Extract::from_source(&tmp_archive_path)
             .extract_file(&tmp_dir, &archive_bin_path)
-            .map_err(|e| ErrorDetails::CLIInstallError { msg: e.to_string() })?;
+            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
 
         let new_exe = tmp_dir.join(&archive_bin_path);
         // Make executable
@@ -121,7 +121,7 @@ impl Command for Update {
         Move::from_source(&new_exe)
             .replace_using_temp(&tmp_file)
             .to_dest(&bin_install_path)
-            .map_err(|e| ErrorDetails::CLIInstallError { msg: e.to_string() })?;
+            .map_err(|e| ErrorDetails::CliInstallError { msg: e.to_string() })?;
 
         info!(
             "{} Succesfully updated to the latest Apollo CLI. Enjoy!",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -27,7 +27,7 @@ fn save(path: &PathBuf, cli_config: &CliConfig) -> Result<(), Box<dyn Error + 's
     let toml = toml::to_string(cli_config).unwrap();
 
     fs::create_dir_all(&path.parent().unwrap())?;
-    debug!("Wrote cli config to path {}", path.to_str().unwrap());
+    debug!("Writing cli config to path {}...", path.to_str().unwrap());
     fs::write(&path, toml).map_err(From::from)
 }
 
@@ -43,7 +43,7 @@ fn load(path: &PathBuf) -> Result<CliConfig, Box<dyn Error + 'static>> {
     s.merge(Environment::with_prefix("APOLLO_").separator("__"))
         .unwrap();
 
-    debug!("Loaded cli config from path {}", path.to_str().unwrap());
+    debug!("Loading cli config from path {}...", path.to_str().unwrap());
     s.try_into().map_err(From::from)
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -49,8 +49,18 @@ impl CliConfig {
             info!("{}", POST_INSTALL_MESSAGE);
         }
 
-        s.merge(Environment::with_prefix("APOLLO_").separator("__")).unwrap();
+        s.merge(Environment::with_prefix("APOLLO_").separator("__"))
+            .unwrap();
         s.try_into().map_err(From::from)
+    }
+}
+
+impl Clone for CliConfig {
+    fn clone(&self) -> CliConfig {
+        CliConfig {
+            machine_id: self.machine_id.clone(),
+            api_key: self.api_key.clone(),
+        }
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -85,15 +85,6 @@ impl CliConfig {
     }
 }
 
-impl Clone for CliConfig {
-    fn clone(&self) -> CliConfig {
-        CliConfig {
-            machine_id: self.machine_id.clone(),
-            api_key: self.api_key.clone(),
-        }
-    }
-}
-
 // #[cfg(test)]
 // mod tests {
 //     use std::env::set_var;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fs;
 
-use config::{Config, ConfigError};
+use config::{Config, ConfigError, Environment};
 use log::info;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -49,6 +49,7 @@ impl CliConfig {
             info!("{}", POST_INSTALL_MESSAGE);
         }
 
+        s.merge(Environment::with_prefix("APOLLO_").separator("__")).unwrap();
         s.try_into().map_err(From::from)
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fs;
 
 use config::{Config, Environment};
-use log::info;
+use log::{info, debug};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -17,6 +17,8 @@ To learn more, checkout https://apollo.dev/cli/telemetry\n";
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliConfig {
     pub machine_id: String,
+    // This can be used for a service api key, or a personal api key.
+    // The CLI doesn't differentiate at the moment.
     pub api_key: Option<String>,
 }
 
@@ -25,6 +27,7 @@ impl CliConfig {
         let toml = toml::to_string(cli_config).unwrap();
 
         fs::create_dir_all(&path.parent().unwrap())?;
+        debug!("Wrote cli config to path {}", path.to_str().unwrap());
         fs::write(&path, toml).map_err(|e| From::from(e))
     }
 
@@ -33,6 +36,8 @@ impl CliConfig {
             machine_id: Uuid::new_v4().to_string(),
             api_key: None,
         };
+
+        debug!("New cli config: {}", serde_json::to_string(&config).unwrap());
 
         CliConfig::save(path, &config)?;
 
@@ -52,6 +57,7 @@ impl CliConfig {
 
         s.merge(Environment::with_prefix("APOLLO_").separator("__"))
             .unwrap();
+        debug!("Loaded cli config from path {}", path.to_str().unwrap());
         s.try_into().map_err(From::from)
     }
 }

--- a/cli/src/errors/details.rs
+++ b/cli/src/errors/details.rs
@@ -47,10 +47,10 @@ Please ensure you have permissions to edit your environment variables."
     InputConfirmationError,
 
     #[error("Could not install CLI. {}", .msg)]
-    CLIInstallError { msg: String },
+    CliInstallError { msg: String },
 
-    #[error("Could not read cli configuration CLI. {}", .msg)]
-    CLIConfigError { msg: String },
+    #[error("Could not read CLI configuration. {}", .msg)]
+    CliConfigError { msg: String },
 }
 
 impl ErrorDetails {
@@ -66,8 +66,8 @@ impl ErrorDetails {
             ErrorDetails::UnsupportedPlatformError { .. } => ExitCode::EnvironmentError,
             ErrorDetails::ReleaseFetchError => ExitCode::NetworkError,
             ErrorDetails::InputConfirmationError => ExitCode::InvalidArguments,
-            ErrorDetails::CLIInstallError { .. } => ExitCode::FileSystemError,
-            ErrorDetails::CLIConfigError { .. } => ExitCode::ConfigurationError,
+            ErrorDetails::CliInstallError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::CliConfigError { .. } => ExitCode::ConfigurationError,
         }
     }
 }

--- a/cli/src/errors/details.rs
+++ b/cli/src/errors/details.rs
@@ -49,8 +49,8 @@ Please ensure you have permissions to edit your environment variables."
     #[error("Could not install CLI. {}", .msg)]
     CliInstallError { msg: String },
 
-    #[error("Could not read CLI configuration. {}", .msg)]
-    CliConfigError { msg: String },
+    #[error("Error loading config file {}: {}", .path, .msg)]
+    CliConfigError { msg: String, path: String },
 }
 
 impl ErrorDetails {

--- a/cli/src/errors/details.rs
+++ b/cli/src/errors/details.rs
@@ -50,7 +50,10 @@ Please ensure you have permissions to edit your environment variables."
     CliInstallError { msg: String },
 
     #[error("Error loading config file {}: {}", .path, .msg)]
-    CliConfigError { msg: String, path: String },
+    CliConfigReadError { msg: String, path: String },
+
+    #[error("Error writing config file {}: {}", .path, .msg)]
+    CliConfigWriteError { msg: String, path: String },
 }
 
 impl ErrorDetails {
@@ -67,7 +70,8 @@ impl ErrorDetails {
             ErrorDetails::ReleaseFetchError => ExitCode::NetworkError,
             ErrorDetails::InputConfirmationError => ExitCode::InvalidArguments,
             ErrorDetails::CliInstallError { .. } => ExitCode::FileSystemError,
-            ErrorDetails::CliConfigError { .. } => ExitCode::ConfigurationError,
+            ErrorDetails::CliConfigReadError { .. } => ExitCode::ConfigurationError,
+            ErrorDetails::CliConfigWriteError { .. } => ExitCode::ConfigurationError,
         }
     }
 }

--- a/cli/src/errors/details.rs
+++ b/cli/src/errors/details.rs
@@ -48,6 +48,9 @@ Please ensure you have permissions to edit your environment variables."
 
     #[error("Could not install CLI. {}", .msg)]
     CLIInstallError { msg: String },
+
+    #[error("Could not read cli configuration CLI. {}", .msg)]
+    CLIConfigError { msg: String },
 }
 
 impl ErrorDetails {
@@ -64,6 +67,7 @@ impl ErrorDetails {
             ErrorDetails::ReleaseFetchError => ExitCode::NetworkError,
             ErrorDetails::InputConfirmationError => ExitCode::InvalidArguments,
             ErrorDetails::CLIInstallError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::CLIConfigError { .. } => ExitCode::ConfigurationError,
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ use console::style;
 use structopt::StructOpt;
 
 use crate::cli::{Apollo, Subcommand};
-use crate::errors::{report, ApolloError, ErrorDetails};
+use crate::errors::{report, ApolloError};
 use crate::log::{init_logger, APOLLO_LOG_LEVEL};
 use crate::telemetry::Session;
 use crate::version::{background_check_for_updates, command_name};
@@ -39,8 +39,7 @@ fn main() {
 
     setup_panic_hooks();
 
-    let session_result = Session::init()
-        .map_err(|e| ApolloError::from(ErrorDetails::CliConfigError { msg: e.to_string() }));
+    let session_result = Session::init();
 
     if let Err(err) = session_result {
         report(&err);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     setup_panic_hooks();
 
     let session_result = Session::init()
-        .map_err(|e| ApolloError::from(ErrorDetails::CLIConfigError { msg: e.to_string() }));
+        .map_err(|e| ApolloError::from(ErrorDetails::CliConfigError { msg: e.to_string() }));
 
     if let Err(err) = session_result {
         report(&err);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,7 +44,11 @@ fn main() {
     if let Err(err) = session_result {
         report(&err);
         let code = err.exit_code();
-        return code.exit()
+        // TODO: FIXME:: https://github.com/apollographql/apollo-cli/pull/50#discussion_r434224921
+        // This line hard exits the application but is visually non-distinct.
+        // There _should_ be some way to refactor this file to make it _painfully_
+        // clear how the CLI will execute, fail, and operate.
+        code.exit()
     };
 
     let mut session = session_result.unwrap();
@@ -82,7 +86,11 @@ fn main() {
         Err(Error::Apollo(err)) => {
             report(&err);
             let code = err.exit_code();
-            return code.exit()
+            // TODO: FIXME:: https://github.com/apollographql/apollo-cli/pull/50#discussion_r434224921
+            // This line hard exits the application but is visually non-distinct.
+            // There _should_ be some way to refactor this file to make it _painfully_
+            // clear how the CLI will execute, fail, and operate.
+            code.exit()
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
     if let Err(err) = session_result {
         report(&err);
         let code = err.exit_code();
-        code.exit();
+        return code.exit()
     };
 
     let mut session = session_result.unwrap();
@@ -82,7 +82,7 @@ fn main() {
         Err(Error::Apollo(err)) => {
             report(&err);
             let code = err.exit_code();
-            code.exit();
+            return code.exit()
         }
     }
 }

--- a/cli/src/style.rs
+++ b/cli/src/style.rs
@@ -2,3 +2,4 @@ use console::Emoji;
 
 pub static ROCKET: Emoji = Emoji("🚀 ", "");
 pub static TADA: Emoji = Emoji("🎉 ", "");
+pub static KEY: Emoji = Emoji("🔐", "");

--- a/cli/src/style.rs
+++ b/cli/src/style.rs
@@ -2,4 +2,4 @@ use console::Emoji;
 
 pub static ROCKET: Emoji = Emoji("🚀 ", "");
 pub static TADA: Emoji = Emoji("🎉 ", "");
-pub static KEY: Emoji = Emoji("🔐", "");
+pub static KEY: Emoji = Emoji("🔑", "");

--- a/cli/src/telemetry/session.rs
+++ b/cli/src/telemetry/session.rs
@@ -9,10 +9,10 @@ use uuid::Uuid;
 
 use crate::config::CliConfig;
 use crate::domain;
-use crate::version::get_installed_version;
+use crate::errors::{ApolloError, ErrorDetails, Fallible};
 use crate::layout::apollo_config;
+use crate::version::get_installed_version;
 use std::path::PathBuf;
-use crate::errors::{ErrorDetails, ApolloError, Fallible};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Platform {
@@ -64,19 +64,16 @@ impl Session {
         };
 
         let release_version = get_installed_version()
-            .map_err(|e|
-                ApolloError::from(
-                    ErrorDetails::CliInstallError { msg: e.to_string()}
-                )
-            )?.to_string();
-      
+            .map_err(|e| ApolloError::from(ErrorDetails::CliInstallError { msg: e.to_string() }))?
+            .to_string();
         let config_path = apollo_config()?;
 
-        let config = CliConfig::load(&config_path)
-            .map_err(|e|
-                ApolloError::from(
-                    ErrorDetails::CliConfigError { msg: e.to_string(), path: config_path.to_str().unwrap().to_string() }
-                ))?;
+        let config = CliConfig::load(&config_path).map_err(|e| {
+            ApolloError::from(ErrorDetails::CliConfigError {
+                msg: e.to_string(),
+                path: config_path.to_str().unwrap().to_string(),
+            })
+        })?;
 
         Ok(Session {
             command,

--- a/cli/src/telemetry/session.rs
+++ b/cli/src/telemetry/session.rs
@@ -91,6 +91,14 @@ impl Session {
         }
 
         let url = format!("{}/telemetry", domain());
+        // TODO: FIXME:: https://github.com/apollographql/apollo-cli/pull/50#discussion_r434231100
+        // Requiring effectively copy paste renaming for
+        // data is a _high_ chance for bugs and no something
+        // we should encourage. This was done to unwed the CLI's
+        // notion of a Session from the Typescript telemetry
+        // notion, however a larger refactor to move Session into
+        // a higher up module, which can send a Telemetry struct
+        // etc.
         let telemetry_session = serde_json::json!({
             "command": self.command,
             "machine_id": self.config.machine_id,

--- a/cli/src/telemetry/session.rs
+++ b/cli/src/telemetry/session.rs
@@ -143,11 +143,11 @@ mod tests {
         let proxy = MockServer::start().await;
 
         let payload_matcher = move |request: &Request| {
-            let body: Session =
+            let body: serde_json::Value =
                 serde_json::from_slice(&request.body).expect("Failed to serialise body");
-            match body.command {
-                Some(cmd) => cmd == "test".to_string(),
-                None => false,
+            match body.get("command").unwrap() {
+                serde_json::Value::String(cmd) => cmd == "test",
+                _ => false,
             }
         };
 

--- a/cli/src/telemetry/session.rs
+++ b/cli/src/telemetry/session.rs
@@ -68,12 +68,7 @@ impl Session {
             .to_string();
         let config_path = apollo_config()?;
 
-        let config = CliConfig::load(&config_path).map_err(|e| {
-            ApolloError::from(ErrorDetails::CliConfigError {
-                msg: e.to_string(),
-                path: config_path.to_str().unwrap().to_string(),
-            })
-        })?;
+        let config = CliConfig::load(&config_path)?;
 
         Ok(Session {
             command,

--- a/cli/src/telemetry/session.rs
+++ b/cli/src/telemetry/session.rs
@@ -45,10 +45,10 @@ pub struct Session {
     /// The current version of the CLI
     release_version: String,
 
-    /// The current instantiation of CLIConfig
+    /// The current instantiation of CliConfig
     pub config: CliConfig,
 
-    /// The current instantiation of CLIConfig
+    /// The current instantiation of CliConfig
     pub config_path: PathBuf,
 }
 

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,12 +1,13 @@
 use crate::errors::ErrorDetails;
 use console::Term;
+use atty::Stream;
 
 // For interactively handling user input
 pub fn input(msg: &str, sensitive: bool) -> Result<String, ErrorDetails> {
     println!("{}", msg);
     let terminal = Term::stdout();
 
-    let mut response: String = if !(sensitive && terminal.is_term()) {
+    let mut response: String = if !(sensitive && atty::is(Stream::Stdin)) {
         read!("{}\n")
     } else {
         terminal.read_secure_line().unwrap()

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,10 +1,18 @@
 use crate::errors::ErrorDetails;
+use console::Term;
 
 // For interactively handling user input
-pub fn input(msg: &str) -> Result<String, ErrorDetails> {
+pub fn input(msg: &str, sensitive: bool) -> Result<String, ErrorDetails> {
     println!("{}", msg);
-    let mut response: String = read!("{}\n");
-    response = response.split_whitespace().collect(); // remove whitespace
+    let terminal = Term::stdout();
+
+    let mut response: String = if !(sensitive && terminal.is_term()) {
+        read!("{}\n")
+    } else {
+        terminal.read_secure_line().unwrap()
+    };
+
+    response = String::from(response.trim()); // remove whitespace
     Ok(response)
 }
 

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,26 +1,29 @@
-use crate::errors::{ErrorDetails, Fallible, ApolloError};
-use console::Term;
+use crate::errors::{ApolloError, ErrorDetails, Fallible};
 use atty::Stream;
+use console::Term;
 use log::debug;
 
-
+// For interactively handling user input
+// Handles reading from stdin, or interactive user input.
 pub fn input(msg: &str) -> Fallible<String> {
     input_or_sensitive(msg, false)
 }
 
+// For interactively handling sensitive user input
+// Handles reading from stdin, or redacted interactive user input.
 pub fn sensitive(msg: &str) -> Fallible<String> {
     input_or_sensitive(msg, true)
 }
 
-// For interactively handling user input
 fn input_or_sensitive(msg: &str, sensitive: bool) -> Fallible<String> {
     println!("{}", msg);
     let terminal = Term::stdout();
 
-    let is_tty = atty::is(Stream::Stdin);
-    debug!("Reading from {}", is_tty ? "tty" : "non-interactive stream");
-
-    let mut response: String = if !(sensitive && is_tty) {
+    let mut response: String = if !sensitive {
+        debug!("Reading...");
+        read!("{}\n")
+    } else if !atty::is(Stream::Stdin) {
+        debug!("Reading from non-interactive stream...");
         read!("{}\n")
     } else {
         debug!("Reading secure line from tty...");

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -25,7 +25,7 @@ const NO: &str = "n";
 // Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
 // and lowercasing logic below.
 pub fn confirm(msg: &str) -> Result<bool, ErrorDetails> {
-    let mut response: String = input(&format!("{} [y/n]", msg))?;
+    let mut response: String = input(&format!("{} [y/n]", msg), false)?;
     response.make_ascii_lowercase(); // ensure response is all lowercase
     response.truncate(INTERACTIVE_RESPONSE_LEN); // at this point, all valid input will be "y" or "n"
 

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,5 +1,13 @@
 use crate::errors::ErrorDetails;
 
+// For interactively handling user input
+pub fn input(msg: &str) -> Result<String, ErrorDetails> {
+    println!("{}", msg);
+    let mut response: String = read!("{}\n");
+    response = response.split_whitespace().collect(); // remove whitespace
+    Ok(response)
+}
+
 // Truncate all "yes", "no" responses for interactive delete prompt to just "y" or "n".
 const INTERACTIVE_RESPONSE_LEN: usize = 1;
 const YES: &str = "y";
@@ -9,9 +17,7 @@ const NO: &str = "n";
 // Input like "yes", "Yes", "no", "No" will be accepted, thanks to the whitespace-stripping
 // and lowercasing logic below.
 pub fn confirm(msg: &str) -> Result<bool, ErrorDetails> {
-    println!("{} [y/n]", msg);
-    let mut response: String = read!("{}\n");
-    response = response.split_whitespace().collect(); // remove whitespace
+    let mut response: String = input(&format!("{} [y/n]", msg))?;
     response.make_ascii_lowercase(); // ensure response is all lowercase
     response.truncate(INTERACTIVE_RESPONSE_LEN); // at this point, all valid input will be "y" or "n"
 

--- a/cli/tests/cli-runtime.rs
+++ b/cli/tests/cli-runtime.rs
@@ -53,11 +53,10 @@ mod unix {
     //         .append_header("content-disposition", "filename=ap-v100.0.0-linux");
     //     let proxy = create_mock_proxy(response).await.unwrap();
 
-    //     let dir = tempdir().unwrap();
-    //     let mut cli = utils::get_bare_cli();
+    //     let mut cli = utils::get_cli();
 
-    //     cli.arg("setup")
-    //         .env("HOME", dir.path())
+    //     cli.command
+    //         .arg("setup")
     //         .env("APOLLO_CDN_URL", &proxy.uri())
     //         .env("SHELL", "/usr/bin/zsh")
     //         .assert()
@@ -72,11 +71,10 @@ mod unix {
     //         ResponseTemplate::new(200).append_header("content-disposition", "filename=ap-v0.1-linux");
 
     //     let proxy = create_mock_proxy(response).await.unwrap();
-    //     let dir = tempdir().unwrap();
-    //     let mut cli = utils::get_bare_cli();
+    //     let mut cli = utils::get_cli();
 
-    //     cli.arg("setup")
-    //         .env("HOME", dir.path())
+    //     cli.command
+    //         .arg("setup")
     //         .env("APOLLO_CDN_URL", &proxy.uri())
     //         .env("SHELL", "/usr/bin/zsh")
     //         .assert()

--- a/cli/tests/cli-runtime.rs
+++ b/cli/tests/cli-runtime.rs
@@ -15,7 +15,7 @@ mod unix {
 
     #[test]
     fn no_command_used() -> Result<(), Box<dyn std::error::Error>> {
-        let mut cli = utils::get_cli();
+        let mut cli = utils::get_cli().command;
 
         cli.assert()
             .code(0)

--- a/cli/tests/commands/auth.rs
+++ b/cli/tests/commands/auth.rs
@@ -1,7 +1,7 @@
 use crate::utils::get_cli;
-use std::process::Stdio;
-use std::io::Write;
 use config::Config;
+use std::io::Write;
+use std::process::Stdio;
 
 #[test]
 fn writes_auth_token() {
@@ -10,79 +10,102 @@ fn writes_auth_token() {
 
     let test_api_key = "test_key";
 
-    let mut cli_spawn = cli.arg("auth")
+    let mut cli_spawn = cli
+        .arg("auth")
         .arg("setup")
         .stdin(Stdio::piped())
         .spawn()
         .unwrap();
 
-
-    cli_spawn.stdin.as_mut().unwrap().write_all(test_api_key.as_ref()).unwrap();
+    cli_spawn
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(test_api_key.as_ref())
+        .unwrap();
     cli_spawn.wait().unwrap();
 
-    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let config_path = test_command
+        .home_dir
+        .path()
+        .join(".apollo")
+        .join("config.toml");
     let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    s.merge(config::File::with_name(config_path.to_str().unwrap()))
+        .unwrap();
     assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
 }
 
 #[test]
 fn verify_overwrite_auth_token() {
     let mut test_command = get_cli();
-    let cli = test_command.command
-        .arg("auth")
-        .arg("setup");
+    let cli = test_command.command.arg("auth").arg("setup");
     let test_api_key = "test_key";
 
     {
-        let mut cli_spawn = cli
-            .stdin(Stdio::piped())
-            .spawn()
+        let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
+
+        cli_spawn
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all("foo-bar".as_ref())
             .unwrap();
-
-
-        cli_spawn.stdin.as_mut().unwrap().write_all("foo-bar".as_ref()).unwrap();
         cli_spawn.wait().unwrap();
     }
 
     {
-        let mut cli_spawn = cli
-            .stdin(Stdio::piped())
-            .spawn()
-            .unwrap();
+        let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
 
-        cli_spawn.stdin.as_mut().unwrap().write_all("y\ntest_key".as_ref()).unwrap();
+        cli_spawn
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all("test_key".as_ref())
+            .unwrap();
         cli_spawn.wait().unwrap();
     }
 
-    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let config_path = test_command
+        .home_dir
+        .path()
+        .join(".apollo")
+        .join("config.toml");
     let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    s.merge(config::File::with_name(config_path.to_str().unwrap()))
+        .unwrap();
     assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
 }
 
 #[test]
 fn verify_environment_variables_for_config() {
     let mut test_command = get_cli();
-    let cli = test_command.command
+    let cli = test_command
+        .command
         .arg("auth")
         .arg("setup")
         .env("APOLLO__API_KEY", "I EXIST");
     let test_api_key = "test_key";
 
     {
-        let mut cli_spawn = cli
-            .stdin(Stdio::piped())
-            .spawn()
+        let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
+
+        cli_spawn
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all("n".as_ref())
             .unwrap();
-
-
-        cli_spawn.stdin.as_mut().unwrap().write_all("n".as_ref()).unwrap();
         cli_spawn.wait().unwrap();
     }
 
-    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let config_path = test_command
+        .home_dir
+        .path()
+        .join(".apollo")
+        .join("config.toml");
     let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    s.merge(config::File::with_name(config_path.to_str().unwrap()))
+        .unwrap();
     assert!(s.get::<String>("api_key").is_err());
 }

--- a/cli/tests/commands/auth.rs
+++ b/cli/tests/commands/auth.rs
@@ -37,6 +37,39 @@ fn writes_auth_token() {
 }
 
 #[test]
+fn writes_auth_token_trims_whitespace() {
+    let test_command = get_cli();
+    let mut cli = test_command.command;
+
+    let test_api_key = "test_key";
+
+    let mut cli_spawn = cli
+        .arg("auth")
+        .arg("setup")
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    cli_spawn
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(format!("    {}  ", test_api_key).as_ref())
+        .unwrap();
+    cli_spawn.wait().unwrap();
+
+    let config_path = test_command
+        .home_dir
+        .path()
+        .join(".apollo")
+        .join("config.toml");
+    let mut s = Config::new();
+    s.merge(config::File::with_name(config_path.to_str().unwrap()))
+        .unwrap();
+    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
+}
+
+#[test]
 fn verify_overwrite_auth_token() {
     let mut test_command = get_cli();
     let cli = test_command.command.arg("auth").arg("setup");
@@ -75,6 +108,45 @@ fn verify_overwrite_auth_token() {
     s.merge(config::File::with_name(config_path.to_str().unwrap()))
         .unwrap();
     assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
+}
+
+#[test]
+fn non_zero_exit_code_when_empty_string_key_entered() {
+    let test_command = get_cli();
+    let mut cli = test_command.command;
+    {
+        let mut cli_spawn = cli
+            .arg("auth")
+            .arg("setup")
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        cli_spawn
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all("".as_ref())
+            .unwrap();
+        assert_ne!(cli_spawn.wait().unwrap().success(), true);
+    }
+
+    {
+        let mut cli_spawn = cli
+            .arg("auth")
+            .arg("setup")
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        cli_spawn
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all("         ".as_ref())
+            .unwrap();
+        assert_ne!(cli_spawn.wait().unwrap().success(), true);
+    }
 }
 
 #[test]

--- a/cli/tests/commands/auth.rs
+++ b/cli/tests/commands/auth.rs
@@ -1,120 +1,17 @@
-use crate::utils::get_cli;
-use config::Config;
-use std::io::Write;
-use std::process::Stdio;
+#[cfg(unix)]
+mod unix {
+    use crate::utils::get_cli;
+    use config::Config;
+    use std::io::Write;
+    use std::process::Stdio;
 
-#[test]
-fn writes_auth_token() {
-    let test_command = get_cli();
-    let mut cli = test_command.command;
+    #[test]
+    fn writes_auth_token() {
+        let test_command = get_cli();
+        let mut cli = test_command.command;
 
-    let test_api_key = "test_key";
+        let test_api_key = "test_key";
 
-    let mut cli_spawn = cli
-        .arg("auth")
-        .arg("setup")
-        .stdin(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    cli_spawn
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(test_api_key.as_ref())
-        .unwrap();
-    cli_spawn.wait().unwrap();
-
-    let config_path = test_command
-        .home_dir
-        .path()
-        .join(".apollo")
-        .join("config.toml");
-    let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap()))
-        .unwrap();
-    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
-}
-
-#[test]
-fn writes_auth_token_trims_whitespace() {
-    let test_command = get_cli();
-    let mut cli = test_command.command;
-
-    let test_api_key = "test_key";
-
-    let mut cli_spawn = cli
-        .arg("auth")
-        .arg("setup")
-        .stdin(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    cli_spawn
-        .stdin
-        .as_mut()
-        .unwrap()
-        .write_all(format!("    {}  ", test_api_key).as_ref())
-        .unwrap();
-    cli_spawn.wait().unwrap();
-
-    let config_path = test_command
-        .home_dir
-        .path()
-        .join(".apollo")
-        .join("config.toml");
-    let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap()))
-        .unwrap();
-    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
-}
-
-#[test]
-fn verify_overwrite_auth_token() {
-    let mut test_command = get_cli();
-    let cli = test_command.command.arg("auth").arg("setup");
-    let test_api_key = "test_key";
-
-    {
-        let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
-
-        cli_spawn
-            .stdin
-            .as_mut()
-            .unwrap()
-            .write_all("foo-bar".as_ref())
-            .unwrap();
-        cli_spawn.wait().unwrap();
-    }
-
-    {
-        let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
-
-        cli_spawn
-            .stdin
-            .as_mut()
-            .unwrap()
-            .write_all("test_key".as_ref())
-            .unwrap();
-        cli_spawn.wait().unwrap();
-    }
-
-    let config_path = test_command
-        .home_dir
-        .path()
-        .join(".apollo")
-        .join("config.toml");
-    let mut s = Config::new();
-    s.merge(config::File::with_name(config_path.to_str().unwrap()))
-        .unwrap();
-    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
-}
-
-#[test]
-fn non_zero_exit_code_when_empty_string_key_entered() {
-    let test_command = get_cli();
-    let mut cli = test_command.command;
-    {
         let mut cli_spawn = cli
             .arg("auth")
             .arg("setup")
@@ -126,12 +23,27 @@ fn non_zero_exit_code_when_empty_string_key_entered() {
             .stdin
             .as_mut()
             .unwrap()
-            .write_all("".as_ref())
+            .write_all(test_api_key.as_ref())
             .unwrap();
-        assert_ne!(cli_spawn.wait().unwrap().success(), true);
+        cli_spawn.wait().unwrap();
+
+        let config_path = test_command
+            .home_dir
+            .path()
+            .join(".apollo")
+            .join("config.toml");
+        let mut s = Config::new();
+        s.merge(config::File::with_name(config_path.to_str().unwrap()))
+            .unwrap();
+        assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
     }
 
-    {
+    #[test]
+    fn writes_auth_token_trims_whitespace() {
+        let test_command = get_cli();
+        let mut cli = test_command.command;
+
+        let test_api_key = "test_key";
         let mut cli_spawn = cli
             .arg("auth")
             .arg("setup")
@@ -143,59 +55,149 @@ fn non_zero_exit_code_when_empty_string_key_entered() {
             .stdin
             .as_mut()
             .unwrap()
-            .write_all("         ".as_ref())
+            .write_all(format!("    {}  ", test_api_key).as_ref())
             .unwrap();
-        assert_ne!(cli_spawn.wait().unwrap().success(), true);
-    }
-}
+        cli_spawn.wait().unwrap();
 
-#[test]
-fn verify_environment_variables_for_config() {
-    {
+        let config_path = test_command
+            .home_dir
+            .path()
+            .join(".apollo")
+            .join("config.toml");
+        let mut s = Config::new();
+        s.merge(config::File::with_name(config_path.to_str().unwrap()))
+            .unwrap();
+        assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
+    }
+
+    #[test]
+    fn verify_overwrite_auth_token() {
         let mut test_command = get_cli();
         let cli = test_command.command.arg("auth").arg("setup");
-        let mut cli_spawn = cli
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-        cli_spawn
-            .stdin
-            .as_mut()
-            .unwrap()
-            .write_all("to be ignored".as_ref())
-            .unwrap();
-        let stderr = cli_spawn.wait_with_output().unwrap().stderr;
-        let output = std::str::from_utf8(&stderr).unwrap();
+        let test_api_key = "test_key";
 
-        // We assert we have not seen a warning since there is _no_ key set
-        assert_ne!(output.contains("WARN"), true);
+        {
+            let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
+
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("foo-bar".as_ref())
+                .unwrap();
+            cli_spawn.wait().unwrap();
+        }
+
+        {
+            let mut cli_spawn = cli.stdin(Stdio::piped()).spawn().unwrap();
+
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("test_key".as_ref())
+                .unwrap();
+            cli_spawn.wait().unwrap();
+        }
+
+        let config_path = test_command
+            .home_dir
+            .path()
+            .join(".apollo")
+            .join("config.toml");
+        let mut s = Config::new();
+        s.merge(config::File::with_name(config_path.to_str().unwrap()))
+            .unwrap();
+        assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
     }
-    {
-        let mut test_command = get_cli();
-        let cli = test_command
-            .command
-            .arg("auth")
-            .arg("setup")
-            .env("APOLLO__API_KEY", "I EXIST");
 
-        let mut cli_spawn = cli
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+    #[test]
+    fn non_zero_exit_code_when_empty_string_key_entered() {
+        let test_command = get_cli();
+        let mut cli = test_command.command;
+        {
+            let mut cli_spawn = cli
+                .arg("auth")
+                .arg("setup")
+                .stdin(Stdio::piped())
+                .spawn()
+                .unwrap();
 
-        cli_spawn
-            .stdin
-            .as_mut()
-            .unwrap()
-            .write_all("to be ignored".as_ref())
-            .unwrap();
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("".as_ref())
+                .unwrap();
+            assert_ne!(cli_spawn.wait().unwrap().success(), true);
+        }
 
-        let stderr = cli_spawn.wait_with_output().unwrap().stderr;
-        let output = std::str::from_utf8(&stderr).unwrap();
+        {
+            let mut cli_spawn = cli
+                .arg("auth")
+                .arg("setup")
+                .stdin(Stdio::piped())
+                .spawn()
+                .unwrap();
 
-        // We assert we have seen a warning since there is key set via env var
-        assert_eq!(output.contains("WARN"), true);
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("         ".as_ref())
+                .unwrap();
+            assert_ne!(cli_spawn.wait().unwrap().success(), true);
+        }
+    }
+
+    #[test]
+    fn verify_environment_variables_for_config() {
+        {
+            let mut test_command = get_cli();
+            let cli = test_command.command.arg("auth").arg("setup");
+            let mut cli_spawn = cli
+                .stdin(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("to be ignored".as_ref())
+                .unwrap();
+            let stderr = cli_spawn.wait_with_output().unwrap().stderr;
+            let output = std::str::from_utf8(&stderr).unwrap();
+
+            // We assert we have not seen a warning since there is _no_ key set
+            assert_ne!(output.contains("WARN"), true);
+        }
+        {
+            let mut test_command = get_cli();
+            let cli = test_command
+                .command
+                .arg("auth")
+                .arg("setup")
+                .env("APOLLO__API_KEY", "I EXIST");
+
+            let mut cli_spawn = cli
+                .stdin(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            cli_spawn
+                .stdin
+                .as_mut()
+                .unwrap()
+                .write_all("to be ignored".as_ref())
+                .unwrap();
+
+            let stderr = cli_spawn.wait_with_output().unwrap().stderr;
+            let output = std::str::from_utf8(&stderr).unwrap();
+
+            // We assert we have seen a warning since there is key set via env var
+            assert_eq!(output.contains("WARN"), true);
+        }
     }
 }

--- a/cli/tests/commands/auth.rs
+++ b/cli/tests/commands/auth.rs
@@ -1,0 +1,62 @@
+use crate::utils::get_cli;
+use std::process::Stdio;
+use std::io::Write;
+use config::Config;
+
+#[test]
+fn writes_auth_token() {
+    let test_command = get_cli();
+    let mut cli = test_command.command;
+
+    let test_api_key = "test_key";
+
+    let mut cli_spawn = cli.arg("auth")
+        .arg("setup")
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+
+    cli_spawn.stdin.as_mut().unwrap().write_all(test_api_key.as_ref()).unwrap();
+    cli_spawn.wait().unwrap();
+
+    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let mut s = Config::new();
+    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
+}
+
+#[test]
+fn verify_overwrite_auth_token() {
+    let mut test_command = get_cli();
+    let cli = test_command.command
+        .arg("auth")
+        .arg("setup");
+    let test_api_key = "test_key";
+
+    {
+        let mut cli_spawn = cli
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+
+        cli_spawn.stdin.as_mut().unwrap().write_all("foo-bar".as_ref()).unwrap();
+        cli_spawn.wait().unwrap();
+    }
+
+    {
+        let mut cli_spawn = cli
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        cli_spawn.stdin.as_mut().unwrap().write_all("y\ntest_key".as_ref()).unwrap();
+        cli_spawn.wait().unwrap();
+    }
+
+    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let mut s = Config::new();
+    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
+}

--- a/cli/tests/commands/auth.rs
+++ b/cli/tests/commands/auth.rs
@@ -60,3 +60,29 @@ fn verify_overwrite_auth_token() {
     s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
     assert_eq!(test_api_key, s.get::<String>("api_key").unwrap());
 }
+
+#[test]
+fn verify_environment_variables_for_config() {
+    let mut test_command = get_cli();
+    let cli = test_command.command
+        .arg("auth")
+        .arg("setup")
+        .env("APOLLO__API_KEY", "I EXIST");
+    let test_api_key = "test_key";
+
+    {
+        let mut cli_spawn = cli
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+
+        cli_spawn.stdin.as_mut().unwrap().write_all("n".as_ref()).unwrap();
+        cli_spawn.wait().unwrap();
+    }
+
+    let config_path = test_command.home_dir.path().join(".apollo").join("config.toml");
+    let mut s = Config::new();
+    s.merge(config::File::with_name(config_path.to_str().unwrap())).unwrap();
+    assert!(s.get::<String>("api_key").is_err());
+}

--- a/cli/tests/commands/mod.rs
+++ b/cli/tests/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -9,9 +9,7 @@ mod unix {
     use std::io::{Read, Result, Write};
     use std::path::PathBuf;
 
-    use tempfile::tempdir;
-
-    use crate::utils::{block_side_effects, get_bare_cli, get_cli};
+    use crate::utils::get_cli;
 
     #[test]
     fn not_found_in_usage() {
@@ -25,35 +23,34 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn errors_with_no_home_environment() {
-        let dir = tempdir().unwrap();
+        let mut cli = get_cli();
 
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
-
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .assert()
             .code(4)
             .stderr(predicate::str::contains(format!(
                 "edit your profile manually to add '{}' to your PATH",
-                dir.path().join(".apollo/bin").to_string_lossy().to_string()
+                cli.home_dir
+                    .path()
+                    .join(".apollo/bin")
+                    .to_string_lossy()
+                    .to_string()
             )));
     }
 
     #[cfg(unix)]
     #[test]
     fn successful_setup_zsh() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let zshrc = create_profile(&dir.path().join(".zshrc"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let zshrc = create_profile(&cli.home_dir.path().join(".zshrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/zsh")
             .assert()
             .code(0)
@@ -70,18 +67,16 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bashrc() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
         // let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
-        let bashrc = create_profile(&dir.path().join(".bashrc"))?;
+        let bashrc = create_profile(&cli.home_dir.path().join(".bashrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -102,17 +97,15 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bash_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let bash_profile = create_profile(&cli.home_dir.path().join(".bash_profile"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -130,18 +123,16 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bashrc_over_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
-        let bashrc = create_profile(&dir.path().join(".bashrc"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let bash_profile = create_profile(&cli.home_dir.path().join(".bash_profile"))?;
+        let bashrc = create_profile(&cli.home_dir.path().join(".bashrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -162,19 +153,17 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_fish() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("set -gx PATH \"$HOME/.apollo/bin\" $PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let fish_path = dir.path().join(".config/fish");
+        let fish_path = cli.home_dir.path().join(".config/fish");
         DirBuilder::new().recursive(true).create(&fish_path)?;
 
         let fish = create_profile(&fish_path.join("config.fish"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/fish")
             .assert()
             .code(0)
@@ -189,16 +178,14 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn removes_existing_apollo_paths() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let mut profile = create_profile(&dir.path().join(".profile"))?;
+        let mut profile = create_profile(&cli.home_dir.path().join(".profile"))?;
         writeln!(profile, "# .apollo/bin")?;
 
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .assert()
             .code(0)
             .stderr(predicate::str::contains("Setup complete"));
@@ -216,17 +203,15 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_custom_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let path = dir.path().join(".my_config_fmt");
+        let path = cli.home_dir.path().join(".my_config_fmt");
         let profile = create_profile(&path)?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("PROFILE", &path.to_string_lossy().to_string())
             .assert()
             .code(0)
@@ -241,11 +226,9 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn warns_if_cannot_write() -> Result<()> {
-        let dir = tempdir().unwrap();
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let path = dir.path().join(".profile");
+        let path = cli.home_dir.path().join(".profile");
         let file = create_profile(&path)?;
         let metadata = file.metadata()?;
         let mut permissions = metadata.permissions();
@@ -253,8 +236,8 @@ mod unix {
         permissions.set_readonly(true);
         set_permissions(path, permissions)?;
 
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .env("APOLLO_LOG_LEVEL", "warn")
             .assert()
             .code(4)

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -295,7 +295,7 @@ mod windows {
 
     #[test]
     fn not_found_in_usage() {
-        let mut cli = get_cli();
+        let mut cli = get_cli().command;
 
         cli.assert()
             .code(0)
@@ -313,7 +313,7 @@ mod windows {
         // delete the Path value in the Environment sub_key
         key.set_value("Path", &";")?;
 
-        let mut cli = get_cli();
+        let mut cli = get_cli().command;
 
         cli.arg("setup")
             .arg("--debug")
@@ -328,7 +328,7 @@ mod windows {
         // delete the Path value in the Environment sub_key
         key.delete_value("Path")?;
 
-        let mut cli_two = get_cli();
+        let mut cli_two = get_cli().command;
 
         cli_two
             .arg("setup")

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -1,4 +1,5 @@
 mod utils;
+mod commands;
 
 #[cfg(unix)]
 mod unix {
@@ -14,7 +15,7 @@ mod unix {
 
     #[test]
     fn not_found_in_usage() {
-        let mut cli = get_cli();
+        let mut cli = get_cli().command;
 
         cli.assert()
             .code(0)

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -1,5 +1,5 @@
-mod utils;
 mod commands;
+mod utils;
 
 #[cfg(unix)]
 mod unix {

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -10,22 +10,22 @@ pub struct TestCommand {
     pub home_dir: TempDir,
 }
 
-pub fn block_telmetry(cmd: &mut Command) {
+fn block_telmetry(cmd: &mut Command) {
     cmd.env("APOLLO_UPDATE_CHECK_DISABLED", "1")
         .env("APOLLO_TELEMETRY_DISABLED", "1");
 }
 
-pub fn block_update_check(cmd: &mut Command) {
+fn block_update_check(cmd: &mut Command) {
     cmd.env("APOLLO_UPDATE_CHECK_DISABLED", "1")
         .env("APOLLO_TELEMETRY_DISABLED", "1");
 }
 
-pub fn block_side_effects(cmd: &mut Command) {
+fn block_side_effects(cmd: &mut Command) {
     block_update_check(cmd);
     block_telmetry(cmd);
 }
 
-pub fn add_home(cmd: &mut Command) -> TempDir {
+fn add_home(cmd: &mut Command) -> TempDir {
     let dir = tempdir().unwrap();
     cmd.env("HOME", dir.path());
     dir
@@ -41,8 +41,4 @@ pub fn get_cli() -> TestCommand {
         command: cli,
         home_dir,
     }
-}
-
-pub fn get_bare_cli() -> std::process::Command {
-    Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -37,7 +37,10 @@ pub fn get_cli() -> TestCommand {
     block_side_effects(&mut cli);
     let home_dir = add_home(&mut cli);
 
-    TestCommand { command: cli, home_dir }
+    TestCommand {
+        command: cli,
+        home_dir,
+    }
 }
 
 pub fn get_bare_cli() -> std::process::Command {

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -1,7 +1,14 @@
-use assert_cmd::prelude::*;
-use tempfile::tempdir;
+use std::process::Command;
 
-use std::process::Command; // Run programs // Used for writing assertions // Add methods on commands
+use assert_cmd::prelude::*;
+use tempfile::{tempdir, TempDir};
+
+// Run programs // Used for writing assertions // Add methods on commands
+
+pub struct TestCommand {
+    pub command: Command,
+    pub home_dir: TempDir,
+}
 
 pub fn block_telmetry(cmd: &mut Command) {
     cmd.env("APOLLO_UPDATE_CHECK_DISABLED", "1")
@@ -18,18 +25,19 @@ pub fn block_side_effects(cmd: &mut Command) {
     block_telmetry(cmd);
 }
 
-pub fn add_home(cmd: &mut Command) {
+pub fn add_home(cmd: &mut Command) -> TempDir {
     let dir = tempdir().unwrap();
     cmd.env("HOME", dir.path());
+    dir
 }
 
-pub fn get_cli() -> std::process::Command {
+pub fn get_cli() -> TestCommand {
     let mut cli = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
 
     block_side_effects(&mut cli);
-    add_home(&mut cli);
+    let home_dir = add_home(&mut cli);
 
-    cli
+    TestCommand { command: cli, home_dir }
 }
 
 pub fn get_bare_cli() -> std::process::Command {


### PR DESCRIPTION
# Motivation

Gravity team is looking to add a number of features to the CLI, namely around schema uploading/download and checks. To start all of this, we want to be able to set the appropriate `API_KEY` in config to allow users to issue many authenticated requests.

## Team

- @AlexanderMann 
- @jsegaran 

## Questions

- [x] for testing, do we want to:
  - mock user input
  - decouple file and user input from the actual config modification
  - etc.
- [x] for env var do we want to:
  - overwrite global config when env var present
  - merge config based on env var prefix, ie:
    - AP_CLI__FOO_BAR__BAZ -> foo-bar {baz: ...} being a merged config
  - similar to K8s and GCP use a different config file path based on an env var
- [x] for configs do we want to allow for a global and local config?
  - if yes, does `auth setup` then result in modifying local?

## Functional Testing

- [x] no config present
  - [x] run `cargo run auth setup` to test user input
    - [x] exit code 0, new key shows up in `cat ~/.apollo/config.toml`
  - [x] run `printf '...' | cargo run auth setup` to test stdin input
    - [x] exit code 0, new key shows up in `cat ~/.apollo/config.toml`
- [x] config present
  - [x] run `cargo run auth setup` to test user input
    - [x] When I hit and confirm `y` to overwrite, exit code 0, new key shows up in `cat ~/.apollo/config.toml`
    - [x] When I hit and confirm `n` to cancel overwrite, exit code 0, old key shows up in `cat ~/.apollo/config.toml`
  - [x] run `printf 'y\n...' | cargo run auth setup` to test stdin input
    - [x] exit code 0, new key shows up in `cat ~/.apollo/config.toml`
  - [x] run `printf 'n\n...' | cargo run auth setup` to test stdin input
    - [x] exit code 0, old key shows up in `cat ~/.apollo/config.toml`

## Suggested Musical Pairing

https://soundcloud.com/megan-thee-stallion/savageremix-feat-beyonce