### PR TITLE
Refactor: Remove unused/uneeded helper test fns

### DIFF
--- a/cli/tests/cli-runtime.rs
+++ b/cli/tests/cli-runtime.rs
@@ -53,11 +53,10 @@ mod unix {
     //         .append_header("content-disposition", "filename=ap-v100.0.0-linux");
     //     let proxy = create_mock_proxy(response).await.unwrap();
 
-    //     let dir = tempdir().unwrap();
-    //     let mut cli = utils::get_bare_cli();
+    //     let mut cli = utils::get_cli();
 
-    //     cli.arg("setup")
-    //         .env("HOME", dir.path())
+    //     cli.command
+    //         .arg("setup")
     //         .env("APOLLO_CDN_URL", &proxy.uri())
     //         .env("SHELL", "/usr/bin/zsh")
     //         .assert()
@@ -72,11 +71,10 @@ mod unix {
     //         ResponseTemplate::new(200).append_header("content-disposition", "filename=ap-v0.1-linux");
 
     //     let proxy = create_mock_proxy(response).await.unwrap();
-    //     let dir = tempdir().unwrap();
-    //     let mut cli = utils::get_bare_cli();
+    //     let mut cli = utils::get_cli();
 
-    //     cli.arg("setup")
-    //         .env("HOME", dir.path())
+    //     cli.command
+    //         .arg("setup")
     //         .env("APOLLO_CDN_URL", &proxy.uri())
     //         .env("SHELL", "/usr/bin/zsh")
     //         .assert()

--- a/cli/tests/setup.rs
+++ b/cli/tests/setup.rs
@@ -9,9 +9,7 @@ mod unix {
     use std::io::{Read, Result, Write};
     use std::path::PathBuf;
 
-    use tempfile::tempdir;
-
-    use crate::utils::{block_side_effects, get_bare_cli, get_cli};
+    use crate::utils::get_cli;
 
     #[test]
     fn not_found_in_usage() {
@@ -25,35 +23,34 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn errors_with_no_home_environment() {
-        let dir = tempdir().unwrap();
+        let mut cli = get_cli();
 
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
-
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .assert()
             .code(4)
             .stderr(predicate::str::contains(format!(
                 "edit your profile manually to add '{}' to your PATH",
-                dir.path().join(".apollo/bin").to_string_lossy().to_string()
+                cli.home_dir
+                    .path()
+                    .join(".apollo/bin")
+                    .to_string_lossy()
+                    .to_string()
             )));
     }
 
     #[cfg(unix)]
     #[test]
     fn successful_setup_zsh() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let zshrc = create_profile(&dir.path().join(".zshrc"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let zshrc = create_profile(&cli.home_dir.path().join(".zshrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/zsh")
             .assert()
             .code(0)
@@ -70,18 +67,16 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bashrc() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
         // let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
-        let bashrc = create_profile(&dir.path().join(".bashrc"))?;
+        let bashrc = create_profile(&cli.home_dir.path().join(".bashrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -102,17 +97,15 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bash_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let bash_profile = create_profile(&cli.home_dir.path().join(".bash_profile"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -130,18 +123,16 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_bashrc_over_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let profile = create_profile(&dir.path().join(".profile"))?;
-        let bash_profile = create_profile(&dir.path().join(".bash_profile"))?;
-        let bashrc = create_profile(&dir.path().join(".bashrc"))?;
+        let profile = create_profile(&cli.home_dir.path().join(".profile"))?;
+        let bash_profile = create_profile(&cli.home_dir.path().join(".bash_profile"))?;
+        let bashrc = create_profile(&cli.home_dir.path().join(".bashrc"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/bash")
             .assert()
             .code(0)
@@ -162,19 +153,17 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_fish() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("set -gx PATH \"$HOME/.apollo/bin\" $PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let fish_path = dir.path().join(".config/fish");
+        let fish_path = cli.home_dir.path().join(".config/fish");
         DirBuilder::new().recursive(true).create(&fish_path)?;
 
         let fish = create_profile(&fish_path.join("config.fish"))?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("SHELL", "/usr/bin/fish")
             .assert()
             .code(0)
@@ -189,16 +178,14 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn removes_existing_apollo_paths() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let mut profile = create_profile(&dir.path().join(".profile"))?;
+        let mut profile = create_profile(&cli.home_dir.path().join(".profile"))?;
         writeln!(profile, "# .apollo/bin")?;
 
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .assert()
             .code(0)
             .stderr(predicate::str::contains("Setup complete"));
@@ -216,17 +203,15 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn successful_setup_custom_profile() -> Result<()> {
-        let dir = tempdir().unwrap();
         let has_apollo = predicate::str::contains("export PATH=\"$HOME/.apollo/bin:$PATH");
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let path = dir.path().join(".my_config_fmt");
+        let path = cli.home_dir.path().join(".my_config_fmt");
         let profile = create_profile(&path)?;
 
-        cli.arg("setup")
+        cli.command
+            .arg("setup")
             .arg("--verbose")
-            .env("HOME", dir.path())
             .env("PROFILE", &path.to_string_lossy().to_string())
             .assert()
             .code(0)
@@ -241,11 +226,9 @@ mod unix {
     #[cfg(unix)]
     #[test]
     fn warns_if_cannot_write() -> Result<()> {
-        let dir = tempdir().unwrap();
-        let mut cli = get_bare_cli();
-        block_side_effects(&mut cli);
+        let mut cli = get_cli();
 
-        let path = dir.path().join(".profile");
+        let path = cli.home_dir.path().join(".profile");
         let file = create_profile(&path)?;
         let metadata = file.metadata()?;
         let mut permissions = metadata.permissions();
@@ -253,8 +236,8 @@ mod unix {
         permissions.set_readonly(true);
         set_permissions(path, permissions)?;
 
-        cli.arg("setup")
-            .env("HOME", dir.path())
+        cli.command
+            .arg("setup")
             .env("APOLLO_LOG_LEVEL", "warn")
             .assert()
             .code(4)

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -10,22 +10,22 @@ pub struct TestCommand {
     pub home_dir: TempDir,
 }
 
-pub fn block_telmetry(cmd: &mut Command) {
+fn block_telmetry(cmd: &mut Command) {
     cmd.env("APOLLO_UPDATE_CHECK_DISABLED", "1")
         .env("APOLLO_TELEMETRY_DISABLED", "1");
 }
 
-pub fn block_update_check(cmd: &mut Command) {
+fn block_update_check(cmd: &mut Command) {
     cmd.env("APOLLO_UPDATE_CHECK_DISABLED", "1")
         .env("APOLLO_TELEMETRY_DISABLED", "1");
 }
 
-pub fn block_side_effects(cmd: &mut Command) {
+fn block_side_effects(cmd: &mut Command) {
     block_update_check(cmd);
     block_telmetry(cmd);
 }
 
-pub fn add_home(cmd: &mut Command) -> TempDir {
+fn add_home(cmd: &mut Command) -> TempDir {
     let dir = tempdir().unwrap();
     cmd.env("HOME", dir.path());
     dir
@@ -41,8 +41,4 @@ pub fn get_cli() -> TestCommand {
         command: cli,
         home_dir,
     }
-}
-
-pub fn get_bare_cli() -> std::process::Command {
-    Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }


### PR DESCRIPTION
# Motivation

While working on #50 @jsegaran and I introduced a new `struct TestCommand` which does a bunch of the boiler plate `cli` setup, and returns the associated thing devs care about as a struct.

Using this, we can effectively eliminate a modest number of dead call sites to various helper commands for testing, or make things private which were once necessary outside the helper `utils` namespace.

## Notes

We aren't convinced this will work forever for all devs, but once we want/need one of these helper fns again, we can just go back to them being `pub`.

## Suggested Musical Pairing

https://soundcloud.com/breakbot/lockdown-boogie-mixtape